### PR TITLE
Better calculation for challenge pages

### DIFF
--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java
@@ -470,24 +470,35 @@ public class ChallengeLogic implements Listener {
 
     private List<Rank> getRanksForPage(int page, List<Rank> ranksOnPage) {
         int rowsToSkip = (page - 1) * ROWS_OF_RANKS;
-        for (Iterator<Rank> it = ranksOnPage.iterator(); it.hasNext(); ) {
-            Rank rank = it.next();
-            int rowsInRank = getRows(rank);
-            if (rowsToSkip <= 0 || ((rowsToSkip - rowsInRank) < 0)) {
+        List<Rank> allRanks = new ArrayList<>(ranksOnPage);
+
+        int i = 1;
+        for (Iterator<Rank> it = ranksOnPage.iterator(); it.hasNext(); i++) {
+            it.next();
+            int rowsInRanks = calculateRows(allRanks.subList(0,i));
+            if (rowsToSkip <= 0 || ((rowsToSkip - rowsInRanks) < 0)) {
                 return ranksOnPage;
             }
-            rowsToSkip -= rowsInRank;
             it.remove();
         }
         return ranksOnPage;
     }
 
     private int calculateRows(List<Rank> ranksOnPage) {
-        int row = 0;
+        int totalRows = 0;
+        int previousRowsOnPage = 0;
+        int currentRows;
+
         for (Rank rank : ranksOnPage) {
-            row += getRows(rank);
+            currentRows = getRows(rank);
+            totalRows += currentRows;
+
+            if(previousRowsOnPage < 5 && (currentRows + previousRowsOnPage) > 5){
+                totalRows = totalRows + (5 - previousRowsOnPage);
+                previousRowsOnPage = currentRows;
+            } else previousRowsOnPage = previousRowsOnPage + currentRows;
         }
-        return row;
+        return totalRows;
     }
 
     private int getRows(Rank rank) {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java
@@ -493,10 +493,12 @@ public class ChallengeLogic implements Listener {
             currentRows = getRows(rank);
             totalRows += currentRows;
 
-            if(previousRowsOnPage < 5 && (currentRows + previousRowsOnPage) > 5){
+            if (previousRowsOnPage < 5 && (currentRows + previousRowsOnPage) > 5) {
                 totalRows = totalRows + (5 - previousRowsOnPage);
                 previousRowsOnPage = currentRows;
-            } else previousRowsOnPage = previousRowsOnPage + currentRows;
+            } else {
+                previousRowsOnPage = previousRowsOnPage + currentRows;
+            }
         }
         return totalRows;
     }


### PR DESCRIPTION
This fixes a problem with the way challenge pages were calculated. The existing logic was faulty for determining:
- number of rows challenges took up
- determining the max number of pages
- the ranks that should go on a page

The problem stemmed from not accounting for challenge ranks that did not complete their display on a page. For example, if there was 4 ranks on a page, but the 4th one did not finish displaying because it wrapped to the next page, that rank would display each of its challenges again on the next page in order to display all challenges on the same page. Over a sufficient number of pages, these extra rows could build up and potentially not display entire ranks. The bug only manifests itself with enough ranks wrapping to the next page. I have tested several variations of challenge setups and all are working.