### PR TITLE
Biome Improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <adventure-api.version>4.9.1</adventure-api.version>
-        <adventure-bukkit.version>4.0.0</adventure-bukkit.version>
+        <adventure-bukkit.version>4.0.0-SNAPSHOT</adventure-bukkit.version>
         <jbannotations.version>19.0.0</jbannotations.version>
         <api.version>${project.version}</api.version>
         <bukkit-utils.version>1.25-SNAPSHOT</bukkit-utils.version>

--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
     <name>Ultimate SkyBlock</name>
 
     <properties>
-        <adventure-api.version>4.8.1</adventure-api.version>
-        <adventure-bukkit.version>4.0.0-SNAPSHOT</adventure-bukkit.version>
+        <adventure-api.version>4.9.1</adventure-api.version>
+        <adventure-bukkit.version>4.0.0</adventure-bukkit.version>
         <jbannotations.version>19.0.0</jbannotations.version>
         <api.version>${project.version}</api.version>
         <bukkit-utils.version>1.25-SNAPSHOT</bukkit-utils.version>

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/Settings.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/Settings.java
@@ -3,6 +3,7 @@ package us.talabrek.ultimateskyblock;
 import dk.lockfuglsang.minecraft.po.I18nUtil;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.inventory.ItemStack;
+import us.talabrek.ultimateskyblock.command.island.BiomeCommand;
 import us.talabrek.ultimateskyblock.handler.WorldEditHandler;
 import dk.lockfuglsang.minecraft.util.ItemStackUtil;
 
@@ -30,6 +31,7 @@ public class Settings {
     public static int general_cooldownInfo;
     public static int general_cooldownRestart;
     public static int general_biomeChange;
+    public static String general_defaultBiome;
     public static boolean extras_sendToSpawn;
     public static boolean extras_obsidianToLava;
     public static String island_schematicName;
@@ -82,6 +84,14 @@ public class Settings {
             }
         } catch (Exception e) {
             general_biomeChange = 3600;
+        }
+        try {
+            general_defaultBiome = config.getString("options.general.defaultBiome");
+            if (!BiomeCommand.biomeExists(general_defaultBiome)) {
+                general_defaultBiome = "OCEAN";
+            }
+        } catch (Exception e) {
+            general_defaultBiome = "OCEAN";
         }
         try {
             general_cooldownRestart = config.getInt("options.general.cooldownRestart");

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/BiomeCommand.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/BiomeCommand.java
@@ -19,30 +19,14 @@ import java.util.Map;
 
 import static dk.lockfuglsang.minecraft.po.I18nUtil.marktr;
 import static dk.lockfuglsang.minecraft.po.I18nUtil.tr;
-import static us.talabrek.ultimateskyblock.util.BiomeUtil.getBiome;
 
 public class BiomeCommand extends RequireIslandCommand {
-    public static final Map<String, Biome> BIOMES = new HashMap<String, Biome>() {
+    public static final Map<String, Biome> BIOMES = new HashMap<>() {
         {
-            put("ocean", Biome.OCEAN);
-            put("jungle", Biome.JUNGLE);
-            put("hell", Biome.NETHER_WASTES);
-            put("sky", Biome.THE_END);
-            put("mushroom", Biome.MUSHROOM_FIELDS);
-            put("swampland", Biome.SWAMP);
-            put("taiga", Biome.SNOWY_TAIGA);
-            put("desert", Biome.DESERT);
-            put("forest", Biome.FOREST);
-            put("plains", Biome.PLAINS);
-            put("extreme_hills", Biome.DARK_FOREST_HILLS);
-            put("deep_ocean", Biome.DEEP_OCEAN);
-            Biome b = getBiome("ICE_PLAINS");
-            if (b != null) {
-                put("ice_plains", b);
-            }
-            b = getBiome("FLOWER_FOREST");
-            if (b != null) {
-                put("flower_forest", b);
+            for (Biome biome : Biome.values()) {
+                if (!biome.name().equalsIgnoreCase("custom")) {
+                    put(biome.name().toLowerCase(), biome);
+                }
             }
         }
     };
@@ -93,16 +77,19 @@ public class BiomeCommand extends RequireIslandCommand {
             }
             BlockVector3 minP = region.getMinimumPoint();
             BlockVector3 maxP = region.getMaximumPoint();
+            if (Settings.island_distance > Settings.island_protectionRange) {
+                int buffer = (Settings.island_distance - Settings.island_protectionRange) / 2;
+                minP.subtract(buffer, 0, buffer);
+                maxP.add(buffer, 0, buffer);
+            }
             if (args.length == 2 && args[1].matches("[0-9]+")) {
                 int radius = Integer.parseInt(args[1], 10);
-                Location loc = location.clone().add(-radius, 0, -radius);
-                if (region.contains(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ())) {
-                    minP = BlockVector3.at(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
-                }
-                loc = location.clone().add(radius, 0, radius);
-                if (region.contains(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ())) {
-                    maxP = BlockVector3.at(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
-                }
+                minP = BlockVector3.at(Math.max(location.getBlockX() - radius, minP.getBlockX()),
+                    Math.max(location.getBlockY() - radius, minP.getBlockY()),
+                    Math.max(location.getBlockZ() - radius, minP.getBlockZ()));
+                maxP = BlockVector3.at(Math.min(location.getBlockX() + radius, maxP.getBlockX()),
+                    Math.min(location.getBlockY() + radius, maxP.getBlockY()),
+                    Math.min(location.getBlockZ() + radius, maxP.getBlockZ()));
                 player.sendMessage(tr("\u00a77The pixies are busy changing the biome near you to \u00a79{0}\u00a77, be patient.", biome));
             } else if (args.length == 2 && args[1].equalsIgnoreCase("chunk")) {
                 Chunk chunk = location.clone().getChunk();

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/imports/wolfwork/WolfWorkUSBImporter.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/imports/wolfwork/WolfWorkUSBImporter.java
@@ -1,5 +1,6 @@
 package us.talabrek.ultimateskyblock.imports.wolfwork;
 
+import us.talabrek.ultimateskyblock.Settings;
 import us.talabrek.ultimateskyblock.challenge.ChallengeCompletion;
 import us.talabrek.ultimateskyblock.handler.WorldGuardHandler;
 import us.talabrek.ultimateskyblock.imports.USBImporter;
@@ -129,7 +130,7 @@ public class WolfWorkUSBImporter implements USBImporter {
             }
             // Not really that important - since it's most likely different!
             islandInfo.setLevel(playerInfo.getIslandLevel());
-            islandInfo.setBiome("OCEAN");
+            islandInfo.setBiome(Settings.general_defaultBiome);
             islandInfo.save();
             WorldGuardHandler.updateRegion(islandInfo);
         }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/IslandInfo.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/IslandInfo.java
@@ -391,7 +391,7 @@ public class IslandInfo implements us.talabrek.ultimateskyblock.api.IslandInfo {
 
     @Override
     public String getBiome() {
-        return config.getString("general.biome", "OCEAN").toUpperCase();
+        return config.getString("general.biome", Settings.general_defaultBiome).toUpperCase();
     }
 
     public void setBiome(@NotNull String biome) {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/world/ChunkRegenerator.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/world/ChunkRegenerator.java
@@ -13,6 +13,7 @@ import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import us.talabrek.ultimateskyblock.Settings;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 
 import java.util.Arrays;
@@ -126,7 +127,7 @@ public class ChunkRegenerator {
                     defaultBiome = Biome.NETHER_WASTES;
                     break;
                 default:
-                    defaultBiome = Biome.OCEAN;
+                    defaultBiome = Biome.valueOf(Settings.general_defaultBiome);
                     break;
             }
         }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/world/SkyBlockChunkGenerator.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/world/SkyBlockChunkGenerator.java
@@ -20,7 +20,7 @@ public class SkyBlockChunkGenerator extends ChunkGenerator {
         for (int x = 0; x <= 15; x++) {
             for (int z = 0; z <= 15; z++) {
                 for (int y = 0; y < world.getMaxHeight(); y++) {
-                    biome.setBiome(x, y, z, Biome.OCEAN);
+                    biome.setBiome(x, y, z, Biome.valueOf(Settings.general_defaultBiome));
                 }
             }
         }


### PR DESCRIPTION
- Replaces the hard-coded biome list with an automatically generated list of available biomes, except "custom".
- Fixes a bug with setting the biome with a range, where if the range fell outside the region it would expand the range to include either the min or max region corner. This bug meant that if you stood next to the edge of your island and ran, for example, "/is biome 5", it could actually set the biome along the entire edge of your island (much larger than the specified range).
- Adds a buffer when setting the entire island biome, if there's space for it. Just adds half the distance between island protection ranges. This ensures that, when possible, if a players sets the biome for their entire island it also covers the edges. Mojang changed biome resolution from 1x1 to 4x4 and added noise to biome edges, so previously if you used "/is setbiome ", it would miss a lot of spots along the edge of an island.
- Enables the default biome option in the config (fixes #19)