### PR TITLE
EntityMatch: use DyeColor enum for entity color

### DIFF
--- a/uSkyBlock-Core/src/main/resources/challenges.yml
+++ b/uSkyBlock-Core/src/main/resources/challenges.yml
@@ -1079,22 +1079,22 @@ ranks:
         - Cow:8
         - Pig:8
         - Chicken:16
-        - Sheep:{"Color":0}
-        - Sheep:{"Color":1}
-        - Sheep:{"Color":2}
-        - Sheep:{"Color":3}
-        - Sheep:{"Color":4}
-        - Sheep:{"Color":5}
-        - Sheep:{"Color":6}
-        - Sheep:{"Color":7}
-        - Sheep:{"Color":8}
-        - Sheep:{"Color":9}
-        - Sheep:{"Color":10}
-        - Sheep:{"Color":11}
-        - Sheep:{"Color":12}
-        - Sheep:{"Color":13}
-        - Sheep:{"Color":14}
-        - Sheep:{"Color":15}
+        - Sheep:{"Color":"WHITE"}
+        - Sheep:{"Color":"ORANGE"}
+        - Sheep:{"Color":"MAGENTA"}
+        - Sheep:{"Color":"LIGHT_BLUE"}
+        - Sheep:{"Color":"YELLOW"}
+        - Sheep:{"Color":"LIME"}
+        - Sheep:{"Color":"PINK"}
+        - Sheep:{"Color":"GRAY"}
+        - Sheep:{"Color":"LIGHT_GRAY"}
+        - Sheep:{"Color":"CYAN"}
+        - Sheep:{"Color":"PURPLE"}
+        - Sheep:{"Color":"BLUE"}
+        - Sheep:{"Color":"BROWN"}
+        - Sheep:{"Color":"GREEN"}
+        - Sheep:{"Color":"RED"}
+        - Sheep:{"Color":"BLACK"}
         reward:
           text: 1 horse, 1 iron horse armor, 5% chance horse armor
           items:
@@ -1764,4 +1764,4 @@ ranks:
 # All commented settings (#) in the above challenges (not the explanation) can be removed to clean up the challenges.yml.
 #
 # DO NOT CHANGE!
-version: 105
+version: 106

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/EntityMatchTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/EntityMatchTest.java
@@ -1,0 +1,58 @@
+package us.talabrek.ultimateskyblock.challenge;
+
+import org.bukkit.DyeColor;
+import org.bukkit.entity.Cow;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Sheep;
+import org.bukkit.material.Colorable;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class EntityMatchTest {
+    @Test
+    public void testMatchColoredSheep() {
+        EntityMatch matcher = new EntityMatch(EntityType.SHEEP, Map.of("Color", "RED"), 1);
+
+        Sheep fakeSheep = mock(Sheep.class, withSettings().extraInterfaces(Colorable.class));
+        when(fakeSheep.getColor()).thenReturn(DyeColor.RED);
+        when(fakeSheep.getType()).thenReturn(EntityType.SHEEP);
+
+        assertEquals("Red Sheep", matcher.getDisplayName());
+        assertEquals(1, matcher.getCount());
+        assertTrue(matcher.matches(fakeSheep));
+
+        when(fakeSheep.getColor()).thenReturn(DyeColor.WHITE);
+        assertFalse(matcher.matches(fakeSheep));
+    }
+
+    @Test
+    public void testMatchLegacyColoredSheep() {
+        EntityMatch matcher = new EntityMatch(EntityType.SHEEP, Map.of("color", 4.0), 9);
+
+        Sheep fakeSheep = mock(Sheep.class, withSettings().extraInterfaces(Colorable.class));
+        when(fakeSheep.getColor()).thenReturn(DyeColor.YELLOW);
+        when(fakeSheep.getType()).thenReturn(EntityType.SHEEP);
+
+        assertEquals("Yellow Sheep", matcher.getDisplayName());
+        assertEquals(9, matcher.getCount());
+        assertTrue(matcher.matches(fakeSheep));
+
+        when(fakeSheep.getColor()).thenReturn(DyeColor.BLACK);
+        assertFalse(matcher.matches(fakeSheep));
+    }
+
+    @Test
+    public void testMatchColoredCow() {
+        EntityMatch matcher = new EntityMatch(EntityType.COW, Map.of("Color", "RED"), 1);
+
+        Cow fakeCow = mock(Cow.class);
+        when(fakeCow.getType()).thenReturn(EntityType.COW);
+
+        assertEquals("Red Cow", matcher.getDisplayName());
+        assertTrue(matcher.matches(fakeCow));
+    }
+}


### PR DESCRIPTION
EntityMatch now supports String-values to lookup the DyeColor of an Entity. Challenges.yml is altered to use this new format. Legacy integer values are mapped to their new enum values. This method is marked deprecated and will be removed in the future.

The old matcher methods based with reflection still exist, it is possible that more advanced users use this feature.