### PR TITLE
Add update checker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,10 @@
     <properties>
         <adventure-api.version>4.9.3</adventure-api.version>
         <adventure-bukkit.version>4.0.1</adventure-bukkit.version>
+        <apache-http.version>4.5.13</apache-http.version>
         <gson.version>2.8.9</gson.version>
         <jbannotations.version>23.0.0</jbannotations.version>
+        <maven-artifact.version>3.8.4</maven-artifact.version>
         <api.version>${project.version}</api.version>
         <bukkit-utils.version>1.25-SNAPSHOT</bukkit-utils.version>
         <paperlib.version>1.0.7</paperlib.version>
@@ -248,6 +250,16 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${gson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${apache-http.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-artifact</artifactId>
+                <version>${maven-artifact.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/uSkyBlock-API/src/main/java/us/talabrek/ultimateskyblock/api/UpdateChecker.java
+++ b/uSkyBlock-API/src/main/java/us/talabrek/ultimateskyblock/api/UpdateChecker.java
@@ -1,0 +1,50 @@
+package us.talabrek.ultimateskyblock.api;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+
+public interface UpdateChecker {
+    URI URL_RELEASE = URI.create("https://www.uskyblock.ovh/versions/release.json");
+    URI URL_STAGING = URI.create("https://www.uskyblock.ovh/versions/staging.json");
+
+    /**
+     * Compares the current version and latest version (if available) to see if there is a new version available.
+     * @return True if new version is available, false otherwise (no new version available or version info unavailable).
+     */
+    boolean isUpdateAvailable();
+
+    /**
+     * Gets the latest release of uSkyBlock. Returns NULL if the version info hasn't been fetched yet or is unavailable.
+     * @return Latest release of uSkyBlock, NULL when unavailable.
+     */
+    @Nullable String getLatestVersion();
+
+    /**
+     * Gets the current version of uSkyBlock running on the server.
+     * @return Current version of uSkyBlock.
+     */
+    @NotNull String getCurrentVersion();
+
+    /**
+     * Fetches the latest version info from the uSkyBlock website. Returns a {@link CompletableFuture <String>},
+     * completes the HTTP request async. The CompletableFuture will contain NULL when version info cannot be obtained.
+     * @param uri URI to use for the HTTP request, official links are
+     * {@link UpdateChecker#URL_RELEASE} and {@link UpdateChecker#URL_STAGING}.
+     * @return CompletableFuture with the latest version info.
+     */
+    CompletableFuture<String> fetchLatestVersion(URI uri);
+
+    /**
+     * Compares two version numbers. Returns a negative integer, zero, or a positive integer as this
+     * object is less than, equal to, or greater than the specified object.
+     * @see Comparable#compareTo(Object).
+     * @param currentVersion Current version number (may contain -SNAPSHOT).
+     * @param newVersion New version number (may contain -SNAPSHOT).
+     * @return Negative integer, zero, or a positive integer as this object is less than,
+     * equal to, or greater than the specified object.
+     */
+    boolean isNewerVersion(String currentVersion, String newVersion);
+}

--- a/uSkyBlock-Core/pom.xml
+++ b/uSkyBlock-Core/pom.xml
@@ -86,11 +86,17 @@
                                     <include>dk.lockfuglsang.minecraft:bukkit-utils</include>
                                     <include>io.papermc:paperlib</include>
                                     <include>net.kyori:*</include>
+                                    <include>org.apache.httpcomponents:httpclient</include>
+                                    <include>org.apache.maven:maven-artifact</include>
                                     <include>org.bstats:*</include>
                                     <include>uSkyBlock:po-utils</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
+                                <relocation>
+                                    <pattern>com.google.code.gson</pattern>
+                                    <shadedPattern>us.talabrek.ultimateskyblock.gson</shadedPattern>
+                                </relocation>
                                 <relocation>
                                     <pattern>dk.lockfuglsang.minecraft</pattern>
                                     <shadedPattern>us.talabrek.ultimateskyblock.utils</shadedPattern>
@@ -104,12 +110,16 @@
                                     <shadedPattern>us.talabrek.ultimateskyblock.kyori</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>org.bstats</pattern>
-                                    <shadedPattern>us.talabrek.ultimateskyblock.metrics</shadedPattern>
+                                    <pattern>org.apache.httpcomponents</pattern>
+                                    <shadedPattern>us.talabrek.ultimateskyblock.apache.httpcomponents</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>com.google.code.gson</pattern>
-                                    <shadedPattern>us.talabrek.ultimateskyblock.gson</shadedPattern>
+                                    <pattern>org.apache.maven</pattern>
+                                    <shadedPattern>us.talabrek.ultimateskyblock.apache.maven</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.bstats</pattern>
+                                    <shadedPattern>us.talabrek.ultimateskyblock.metrics</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>
@@ -483,6 +493,17 @@
             <artifactId>commons-lang</artifactId>
             <version>2.6</version>
             <scope>provided</scope>
+        </dependency>
+        <!-- Apache HttpComponents -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <scope>compile</scope>
         </dependency>
         <!-- TESTING -->
         <dependency>

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/SkyUpdateChecker.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/SkyUpdateChecker.java
@@ -1,0 +1,115 @@
+package us.talabrek.ultimateskyblock;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.apache.maven.artifact.versioning.ComparableVersion;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import us.talabrek.ultimateskyblock.api.UpdateChecker;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+
+public class SkyUpdateChecker implements UpdateChecker {
+    private String latestVersion;
+
+    private final Gson gson = new Gson();
+    private final uSkyBlock plugin;
+
+    public SkyUpdateChecker(uSkyBlock plugin) {
+        this.plugin = plugin;
+    }
+
+    /**
+     * Triggers an update of the latest version info from the uSkyBlock website, and will log an INFO message if
+     * an update is available.
+     */
+    public void checkForUpdates() {
+        URI uri = URL_RELEASE;
+
+        if (plugin.getConfig().getString("plugin-updates.branch", "RELEASE").equalsIgnoreCase("STAGING")) {
+            uri = URL_STAGING;
+        }
+
+        fetchLatestVersion(uri).thenAccept(version -> {
+            latestVersion = version;
+            if (latestVersion == null) {
+                plugin.getLogger().info("Failed to check for new uSkyBlock versions.");
+            }
+
+            if (isUpdateAvailable()) {
+                plugin.getLogger().info("There is a new version of uSkyBlock available: " + getLatestVersion());
+                plugin.getLogger().info("Visit https://www.uskyblock.ovh/get to download.");
+            }
+        });
+    }
+
+    public boolean isUpdateAvailable() {
+        if (latestVersion != null) {
+            return isNewerVersion(getCurrentVersion(), getLatestVersion());
+        }
+        return false;
+    }
+
+    public @Nullable String getLatestVersion() {
+        return latestVersion;
+    }
+
+    public @NotNull String getCurrentVersion() {
+        return plugin.getDescription().getVersion();
+    }
+
+    public CompletableFuture<String> fetchLatestVersion(URI uri) {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        future.completeAsync(() -> {
+            try {
+                String userAgent = "uSkyBlock-Plugin/v" + getCurrentVersion() + " (www.uskyblock.ovh)";
+                HttpClient httpclient = HttpClients.custom().setUserAgent(userAgent).build();
+
+                int CONNECTION_TIMEOUT_MS = 10 * 1000; // Timeout in millis.
+                RequestConfig requestConfig = RequestConfig.custom()
+                    .setConnectionRequestTimeout(CONNECTION_TIMEOUT_MS)
+                    .setConnectTimeout(CONNECTION_TIMEOUT_MS)
+                    .setSocketTimeout(CONNECTION_TIMEOUT_MS)
+                    .build();
+
+                HttpGet request = new HttpGet(uri);
+                request.setConfig(requestConfig);
+                HttpResponse response = httpclient.execute(request);
+                HttpEntity entity = response.getEntity();
+
+                int status = response.getStatusLine().getStatusCode();
+                if (status < 200 || status >= 300) {
+                    return null;
+                }
+
+                if (entity != null) {
+                    JsonObject obj = gson.fromJson(EntityUtils.toString(entity), JsonObject.class);
+                    if (obj.has("version")) {
+                        return obj.get("version").getAsString();
+                    }
+                }
+            } catch (Exception ex) {
+                plugin.getLogger().warning("Exception while trying to fetch latest plugin version.");
+                ex.printStackTrace();
+            }
+
+            return null;
+        });
+
+        return future;
+    }
+
+    public boolean isNewerVersion(String currentVersion, String newVersion) {
+        ComparableVersion current = new ComparableVersion(currentVersion);
+        ComparableVersion target = new ComparableVersion(newVersion);
+        return target.compareTo(current) > 0;
+    }
+}

--- a/uSkyBlock-Core/src/main/resources/config.yml
+++ b/uSkyBlock-Core/src/main/resources/config.yml
@@ -435,6 +435,12 @@ tool-menu:
     CRAFTING_TABLE: challenges
     BEDROCK: island spawn
 
+plugin-updates:
+  # Should we check for updates and log a message if an update is available
+  check: true
+  # Possible options: RELEASE or STAGING
+  branch: RELEASE
+
 # Placeholders - enable these to get placeholder substitution
 # usb_version
 # usb_island_level, usb_island_level_int
@@ -456,7 +462,7 @@ placeholder:
   servercommandplaceholder: false
 
 # DO NOT TOUCH THE FIELDS BELOW
-version: 107
+version: 108
 force-replace:
   options.party.invite-timeout: 100
   options.island.islandTeleportDelay: 5


### PR DESCRIPTION
This PR adds an update checker to uSkyBlock. The UpdateChecker itself is an API interface, but the methods to get the UpdateChecker are not yet added to the API. I'd prefer to change the way users get the API instance first, because this setup isn't ideal. I'd like to move it away from the main class.

Checks for updates every 4 hours, can be disabled via the config, and will log to the plugin logger and /usb version if an update is available. Alerting admins ingame might be added in the future.

Version info is automatically rsync'ed to our website by GH Actions.