### PR TITLE
uSkyBlock-APIv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,32 @@ Pre-releases will end in -SNAPSHOT, and is considered **unsafe** for production 
 
 Releases have a clean version number, has been tested, and should be safe for production servers.
 
+# New Maven group/artifactId
+Starting with version 3.0.0-SNAPSHOT, we've changed our Maven groupId's for all submodules except uSkyBlock-API.
+If you're using uSkyBlock-Core or po-utils as dependency in your project, update your
+dependencies to:
+
+```xml
+<dependency>
+    <groupId>ovh.uskyblock</groupId>
+    <artifactId>uSkyBlock-Core</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+</dependency>
+```
+
+We're moving new API features towards APIv2, which is available as:
+
+```xml
+<dependency>
+    <groupId>ovh.uskyblock</groupId>
+    <artifactId>uSkyBlock-APIv2</artifactId>
+    <version>3.0.0-SNAPSHOT</version>
+</dependency>
+```
+
+Feel free to use any of the new APIv2 functions on servers running uSkyBlock 3.0.0+. The old API-methods will
+be deprecated and removed in the upcoming plugin releases.
+
 ### Bukkit/Spigot 1.7.9/10 Releases
 
 We provide pre-compiled versions (no support) [here](http://rlf.github.io/uSkyBlock):

--- a/po-utils/pom.xml
+++ b/po-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>uSkyBlock</artifactId>
         <groupId>ovh.uskyblock</groupId>
-        <version>2.12.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>ovh.uskyblock</groupId>
     <artifactId>uSkyBlock</artifactId>
     <packaging>pom</packaging>
-    <version>2.12.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <name>Ultimate SkyBlock</name>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,11 @@
             </dependency>
             <dependency>
                 <groupId>ovh.uskyblock</groupId>
+                <artifactId>uSkyBlock-APIv2</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>ovh.uskyblock</groupId>
                 <artifactId>uSkyBlock-Core</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>uSkyBlock</groupId>
+    <groupId>ovh.uskyblock</groupId>
     <artifactId>uSkyBlock</artifactId>
     <packaging>pom</packaging>
     <version>2.12.0-SNAPSHOT</version>
@@ -39,6 +39,7 @@
     <modules>
         <module>po-utils</module>
         <module>uSkyBlock-API</module>
+        <module>uSkyBlock-APIv2</module>
         <module>uSkyBlock-Core</module>
         <module>uSkyBlock-Plugin</module>
         <module>uSkyBlock-FAWE</module>
@@ -207,22 +208,22 @@
                 <version>${api.version}</version>
             </dependency>
             <dependency>
-                <groupId>uSkyBlock</groupId>
+                <groupId>ovh.uskyblock</groupId>
                 <artifactId>uSkyBlock-Core</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>uSkyBlock</groupId>
+                <groupId>ovh.uskyblock</groupId>
                 <artifactId>uSkyBlock-FAWE</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>uSkyBlock</groupId>
+                <groupId>ovh.uskyblock</groupId>
                 <artifactId>uSkyBlock-AWE370</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>uSkyBlock</groupId>
+                <groupId>ovh.uskyblock</groupId>
                 <artifactId>po-utils</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/uSkyBlock-API/pom.xml
+++ b/uSkyBlock-API/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.rlf</groupId>
     <artifactId>uSkyBlock-API</artifactId>
-    <version>2.12.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/uSkyBlock-APIv2/pom.xml
+++ b/uSkyBlock-APIv2/pom.xml
@@ -9,9 +9,16 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>
-    <artifactId>po-utils</artifactId>
+    <artifactId>uSkyBlock-APIv2</artifactId>
 
     <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>${spigotapi.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>

--- a/uSkyBlock-APIv2/pom.xml
+++ b/uSkyBlock-APIv2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>uSkyBlock</artifactId>
         <groupId>ovh.uskyblock</groupId>
-        <version>2.12.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/uSkyBlock-APIv2/src/main/java/us/talabrek/ultimateskyblock/api/UltimateSkyblock.java
+++ b/uSkyBlock-APIv2/src/main/java/us/talabrek/ultimateskyblock/api/UltimateSkyblock.java
@@ -1,0 +1,4 @@
+package us.talabrek.ultimateskyblock.api;
+
+public interface UltimateSkyblock {
+}

--- a/uSkyBlock-APIv2/src/main/java/us/talabrek/ultimateskyblock/api/UltimateSkyblock.java
+++ b/uSkyBlock-APIv2/src/main/java/us/talabrek/ultimateskyblock/api/UltimateSkyblock.java
@@ -1,4 +1,12 @@
 package us.talabrek.ultimateskyblock.api;
 
+import org.jetbrains.annotations.NotNull;
+import us.talabrek.ultimateskyblock.api.plugin.PluginInfo;
+
 public interface UltimateSkyblock {
+    /**
+     * Gets the {@link PluginInfo}, providing general information about this Ultimate Skyblock instance.
+     * @return General plugin information.
+     */
+    @NotNull PluginInfo getPluginInfo();
 }

--- a/uSkyBlock-APIv2/src/main/java/us/talabrek/ultimateskyblock/api/UltimateSkyblockProvider.java
+++ b/uSkyBlock-APIv2/src/main/java/us/talabrek/ultimateskyblock/api/UltimateSkyblockProvider.java
@@ -1,0 +1,46 @@
+package us.talabrek.ultimateskyblock.api;
+
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+public final class UltimateSkyblockProvider {
+    private static UltimateSkyblock instance = null;
+
+    /**
+     * Gets the API instance of {@link UltimateSkyblock}, will throw {@link IllegalStateException} when the
+     * API isn't loaded yet.
+     *
+     * Convenience method, using Bukkit's {@link org.bukkit.plugin.ServicesManager} is the preferred way to get
+     * an API instance.
+     * @return UltimateSkyblock API instance.
+     * @throws IllegalStateException when the API isn't loaded yet.
+     */
+    public static @NotNull UltimateSkyblock getInstance() {
+        if (instance == null) {
+            throw new IllegalStateException("UltimateSkyblock isn't loaded yet!");
+        }
+        return instance;
+    }
+
+    /**
+     * Internal method - Registers the uSkyBlock plugin instance with the API provider.
+     * @param instance uSkyBlock plugin instance
+     */
+    @ApiStatus.Internal
+    public static void registerPlugin(UltimateSkyblock instance) {
+        UltimateSkyblockProvider.instance = instance;
+    }
+
+    /**
+     * Internal method - Deregisters the uSkyBlock plugin instance with the API provider.
+     */
+    @ApiStatus.Internal
+    public static void deregisterPlugin() {
+        UltimateSkyblockProvider.instance = null;
+    }
+
+    /**
+     * No instance of this class should exist.
+     */
+    private UltimateSkyblockProvider() {}
+}

--- a/uSkyBlock-APIv2/src/main/java/us/talabrek/ultimateskyblock/api/plugin/PluginInfo.java
+++ b/uSkyBlock-APIv2/src/main/java/us/talabrek/ultimateskyblock/api/plugin/PluginInfo.java
@@ -1,0 +1,21 @@
+package us.talabrek.ultimateskyblock.api.plugin;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Provides general information about the Ultimate Skyblock plugin instance running.
+ */
+public interface PluginInfo {
+    /**
+     * Gets the plugin version running on the server.
+     * @return Plugin version running.
+     */
+    @NotNull String getPluginVersion();
+
+    /**
+     * Gets the {@link UpdateChecker}, which provides various information about the current and latest
+     * Ultimate Skyblock releases.
+     * @return Update checker for Ultimate Skyblock.
+     */
+    @NotNull UpdateChecker getUpdateChecker();
+}

--- a/uSkyBlock-APIv2/src/main/java/us/talabrek/ultimateskyblock/api/plugin/UpdateChecker.java
+++ b/uSkyBlock-APIv2/src/main/java/us/talabrek/ultimateskyblock/api/plugin/UpdateChecker.java
@@ -1,0 +1,50 @@
+package us.talabrek.ultimateskyblock.api.plugin;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+
+public interface UpdateChecker {
+    URI URL_RELEASE = URI.create("https://www.uskyblock.ovh/versions/release.json");
+    URI URL_STAGING = URI.create("https://www.uskyblock.ovh/versions/staging.json");
+
+    /**
+     * Compares the current version and latest version (if available) to see if there is a new version available.
+     * @return True if new version is available, false otherwise (no new version available or version info unavailable).
+     */
+    boolean isUpdateAvailable();
+
+    /**
+     * Gets the latest release of uSkyBlock. Returns NULL if the version info hasn't been fetched yet or is unavailable.
+     * @return Latest release of uSkyBlock, NULL when unavailable.
+     */
+    @Nullable String getLatestVersion();
+
+    /**
+     * Gets the current version of uSkyBlock running on the server.
+     * @return Current version of uSkyBlock.
+     */
+    @NotNull String getCurrentVersion();
+
+    /**
+     * Fetches the latest version info from the uSkyBlock website. Returns a {@link CompletableFuture <String>},
+     * completes the HTTP request async. The CompletableFuture will contain NULL when version info cannot be obtained.
+     * @param uri URI to use for the HTTP request, official links are
+     * {@link UpdateChecker#URL_RELEASE} and {@link UpdateChecker#URL_STAGING}.
+     * @return CompletableFuture with the latest version info.
+     */
+    CompletableFuture<String> fetchLatestVersion(URI uri);
+
+    /**
+     * Compares two version numbers. Returns a negative integer, zero, or a positive integer as this
+     * object is less than, equal to, or greater than the specified object.
+     * @see Comparable#compareTo(Object).
+     * @param currentVersion Current version number (may contain -SNAPSHOT).
+     * @param newVersion New version number (may contain -SNAPSHOT).
+     * @return Negative integer, zero, or a positive integer as this object is less than,
+     * equal to, or greater than the specified object.
+     */
+    boolean isNewerVersion(String currentVersion, String newVersion);
+}

--- a/uSkyBlock-AWE370/pom.xml
+++ b/uSkyBlock-AWE370/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>uSkyBlock</artifactId>
         <groupId>ovh.uskyblock</groupId>
-        <version>2.12.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>uSkyBlock-AWE370</artifactId>

--- a/uSkyBlock-AWE370/pom.xml
+++ b/uSkyBlock-AWE370/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>uSkyBlock</artifactId>
-        <groupId>uSkyBlock</groupId>
+        <groupId>ovh.uskyblock</groupId>
         <version>2.12.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -24,7 +24,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>uSkyBlock</groupId>
+            <groupId>ovh.uskyblock</groupId>
             <artifactId>uSkyBlock-Core</artifactId>
         </dependency>
         <dependency>

--- a/uSkyBlock-Core/pom.xml
+++ b/uSkyBlock-Core/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>uSkyBlock</artifactId>
-        <groupId>uSkyBlock</groupId>
+        <groupId>ovh.uskyblock</groupId>
         <version>2.12.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -353,7 +353,7 @@
             <classifier>tests</classifier>
         </dependency>
         <dependency>
-            <groupId>uSkyBlock</groupId>
+            <groupId>ovh.uskyblock</groupId>
             <artifactId>po-utils</artifactId>
         </dependency>
         <dependency>

--- a/uSkyBlock-Core/pom.xml
+++ b/uSkyBlock-Core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>uSkyBlock</artifactId>
         <groupId>ovh.uskyblock</groupId>
-        <version>2.12.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/uSkyBlock-Core/pom.xml
+++ b/uSkyBlock-Core/pom.xml
@@ -361,6 +361,10 @@
             <artifactId>uSkyBlock-API</artifactId>
         </dependency>
         <dependency>
+            <groupId>ovh.uskyblock</groupId>
+            <artifactId>uSkyBlock-APIv2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>net.milkbowl.vault</groupId>
             <artifactId>VaultAPI</artifactId>
             <scope>provided</scope>

--- a/uSkyBlock-Core/pom.xml
+++ b/uSkyBlock-Core/pom.xml
@@ -89,7 +89,7 @@
                                     <include>org.apache.httpcomponents:httpclient</include>
                                     <include>org.apache.maven:maven-artifact</include>
                                     <include>org.bstats:*</include>
-                                    <include>uSkyBlock:po-utils</include>
+                                    <include>ovh.uskyblock:po-utils</include>
                                 </includes>
                             </artifactSet>
                             <relocations>

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/SkyUpdateChecker.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/SkyUpdateChecker.java
@@ -12,7 +12,7 @@ import org.apache.http.util.EntityUtils;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import us.talabrek.ultimateskyblock.api.UpdateChecker;
+import us.talabrek.ultimateskyblock.api.plugin.UpdateChecker;
 
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/api/impl/UltimateSkyblockApi.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/api/impl/UltimateSkyblockApi.java
@@ -1,0 +1,32 @@
+package us.talabrek.ultimateskyblock.api.impl;
+
+import org.jetbrains.annotations.NotNull;
+import us.talabrek.ultimateskyblock.api.UltimateSkyblock;
+import us.talabrek.ultimateskyblock.api.plugin.PluginInfo;
+import us.talabrek.ultimateskyblock.api.plugin.UpdateChecker;
+import us.talabrek.ultimateskyblock.uSkyBlock;
+
+public class UltimateSkyblockApi implements UltimateSkyblock, PluginInfo {
+    private final uSkyBlock plugin;
+
+    public UltimateSkyblockApi(uSkyBlock plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public @NotNull PluginInfo getPluginInfo() {
+        return this;
+    }
+
+    /* PluginInfo impl */
+
+    @Override
+    public @NotNull String getPluginVersion() {
+        return plugin.getUpdateChecker().getCurrentVersion();
+    }
+
+    @Override
+    public @NotNull UpdateChecker getUpdateChecker() {
+        return plugin.getUpdateChecker();
+    }
+}

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/uSkyBlock.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/uSkyBlock.java
@@ -22,6 +22,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.bukkit.plugin.PluginManager;
+import org.bukkit.plugin.ServicePriority;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
@@ -29,6 +30,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import us.talabrek.ultimateskyblock.api.IslandLevel;
 import us.talabrek.ultimateskyblock.api.IslandRank;
+import us.talabrek.ultimateskyblock.api.UltimateSkyblock;
+import us.talabrek.ultimateskyblock.api.UltimateSkyblockProvider;
 import us.talabrek.ultimateskyblock.api.async.Callback;
 import us.talabrek.ultimateskyblock.api.event.EventLogic;
 import us.talabrek.ultimateskyblock.api.event.uSkyBlockEvent;
@@ -110,7 +113,7 @@ import static dk.lockfuglsang.minecraft.po.I18nUtil.pre;
 import static dk.lockfuglsang.minecraft.po.I18nUtil.tr;
 import static us.talabrek.ultimateskyblock.util.LogUtil.log;
 
-public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManager.RequirementChecker {
+public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManager.RequirementChecker, UltimateSkyblock {
     private static final String CN = uSkyBlock.class.getName();
     private static final String[][] depends = new String[][]{
             new String[]{"Vault", "1.7.1", "optional"},
@@ -171,6 +174,8 @@ public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManage
 
     @Override
     public void onDisable() {
+        deregisterApi();
+
         HandlerList.unregisterAll(this);
         Bukkit.getScheduler().cancelTasks(this);
         try {
@@ -206,8 +211,9 @@ public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManage
         FileUtil.setDataFolder(getDataFolder());
         FileUtil.setAllwaysOverwrite("levelConfig.yml");
         I18nUtil.setDataFolder(getDataFolder());
-
         reloadConfigs();
+
+        registerApi();
 
         getServer().getScheduler().runTaskLater(getInstance(), new Runnable() {
             @Override
@@ -1144,5 +1150,21 @@ public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManage
         for (String cmd : cmdList) {
             execCommand(player, cmd, false);
         }
+    }
+
+    /**
+     * Register this uSkyBlock instance with our API provider and Bukkit's ServicesManager.
+     */
+    private void registerApi() {
+        UltimateSkyblockProvider.registerPlugin(this);
+        getServer().getServicesManager().register(UltimateSkyblock.class, this, this, ServicePriority.Normal);
+    }
+
+    /**
+     * Deregister this uSkyBlock instance with our API provider and Bukkit's ServicesManager.
+     */
+    private void deregisterApi() {
+        UltimateSkyblockProvider.deregisterPlugin();
+        getServer().getServicesManager().unregister(this);
     }
 }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/uSkyBlock.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/uSkyBlock.java
@@ -36,6 +36,7 @@ import us.talabrek.ultimateskyblock.api.async.Callback;
 import us.talabrek.ultimateskyblock.api.event.EventLogic;
 import us.talabrek.ultimateskyblock.api.event.uSkyBlockEvent;
 import us.talabrek.ultimateskyblock.api.event.uSkyBlockScoreChangedEvent;
+import us.talabrek.ultimateskyblock.api.impl.UltimateSkyblockApi;
 import us.talabrek.ultimateskyblock.api.uSkyBlockAPI;
 import us.talabrek.ultimateskyblock.challenge.ChallengeLogic;
 import us.talabrek.ultimateskyblock.chat.ChatEvents;
@@ -113,7 +114,7 @@ import static dk.lockfuglsang.minecraft.po.I18nUtil.pre;
 import static dk.lockfuglsang.minecraft.po.I18nUtil.tr;
 import static us.talabrek.ultimateskyblock.util.LogUtil.log;
 
-public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManager.RequirementChecker, UltimateSkyblock {
+public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManager.RequirementChecker {
     private static final String CN = uSkyBlock.class.getName();
     private static final String[][] depends = new String[][]{
             new String[]{"Vault", "1.7.1", "optional"},
@@ -167,6 +168,7 @@ public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManage
     private volatile boolean maintenanceMode = false;
     private BlockLimitLogic blockLimitLogic;
 
+    private UltimateSkyblockApi api;
     private SkyUpdateChecker updateChecker;
 
     public uSkyBlock() {
@@ -174,7 +176,8 @@ public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManage
 
     @Override
     public void onDisable() {
-        deregisterApi();
+        deregisterApi(api);
+        api = null;
 
         HandlerList.unregisterAll(this);
         Bukkit.getScheduler().cancelTasks(this);
@@ -213,7 +216,8 @@ public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManage
         I18nUtil.setDataFolder(getDataFolder());
         reloadConfigs();
 
-        registerApi();
+        api = new UltimateSkyblockApi(this);
+        registerApi(api);
 
         getServer().getScheduler().runTaskLater(getInstance(), new Runnable() {
             @Override
@@ -1155,16 +1159,16 @@ public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManage
     /**
      * Register this uSkyBlock instance with our API provider and Bukkit's ServicesManager.
      */
-    private void registerApi() {
-        UltimateSkyblockProvider.registerPlugin(this);
-        getServer().getServicesManager().register(UltimateSkyblock.class, this, this, ServicePriority.Normal);
+    private void registerApi(UltimateSkyblock api) {
+        UltimateSkyblockProvider.registerPlugin(api);
+        getServer().getServicesManager().register(UltimateSkyblock.class, api, this, ServicePriority.Normal);
     }
 
     /**
      * Deregister this uSkyBlock instance with our API provider and Bukkit's ServicesManager.
      */
-    private void deregisterApi() {
+    private void deregisterApi(UltimateSkyblock api) {
         UltimateSkyblockProvider.deregisterPlugin();
-        getServer().getServicesManager().unregister(this);
+        getServer().getServicesManager().unregister(api);
     }
 }

--- a/uSkyBlock-FAWE/pom.xml
+++ b/uSkyBlock-FAWE/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>uSkyBlock</artifactId>
         <groupId>ovh.uskyblock</groupId>
-        <version>2.12.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>uSkyBlock-FAWE</artifactId>

--- a/uSkyBlock-FAWE/pom.xml
+++ b/uSkyBlock-FAWE/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>uSkyBlock</artifactId>
-        <groupId>uSkyBlock</groupId>
+        <groupId>ovh.uskyblock</groupId>
         <version>2.12.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -25,7 +25,7 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>uSkyBlock</groupId>
+            <groupId>ovh.uskyblock</groupId>
             <artifactId>uSkyBlock-Core</artifactId>
         </dependency>
         <dependency>

--- a/uSkyBlock-Plugin/pom.xml
+++ b/uSkyBlock-Plugin/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>uSkyBlock</artifactId>
-        <groupId>uSkyBlock</groupId>
+        <groupId>ovh.uskyblock</groupId>
         <version>2.12.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -63,15 +63,15 @@
             <artifactId>uSkyBlock-API</artifactId>
         </dependency>
         <dependency>
-            <groupId>uSkyBlock</groupId>
+            <groupId>ovh.uskyblock</groupId>
             <artifactId>uSkyBlock-Core</artifactId>
         </dependency>
         <dependency>
-            <groupId>uSkyBlock</groupId>
+            <groupId>ovh.uskyblock</groupId>
             <artifactId>uSkyBlock-FAWE</artifactId>
         </dependency>
         <dependency>
-            <groupId>uSkyBlock</groupId>
+            <groupId>ovh.uskyblock</groupId>
             <artifactId>uSkyBlock-AWE370</artifactId>
         </dependency>
     </dependencies>

--- a/uSkyBlock-Plugin/pom.xml
+++ b/uSkyBlock-Plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>uSkyBlock</artifactId>
         <groupId>ovh.uskyblock</groupId>
-        <version>2.12.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/uSkyBlock-Plugin/src/assembly/plugin.xml
+++ b/uSkyBlock-Plugin/src/assembly/plugin.xml
@@ -10,9 +10,9 @@
         <dependencySet>
             <includes>
                 <include>com.github.rlf:uSkyBlock-API</include>
-                <include>uSkyBlock:uSkyBlock-Core</include>
-                <include>uSkyBlock:uSkyBlock-FAWE</include>
-                <include>uSkyBlock:uSkyBlock-AWE370</include>
+                <include>ovh.uskyblock:uSkyBlock-Core</include>
+                <include>ovh.uskyblock:uSkyBlock-FAWE</include>
+                <include>ovh.uskyblock:uSkyBlock-AWE370</include>
             </includes>
             <unpack>true</unpack>
         </dependencySet>

--- a/uSkyBlock-Plugin/src/assembly/plugin.xml
+++ b/uSkyBlock-Plugin/src/assembly/plugin.xml
@@ -10,6 +10,7 @@
         <dependencySet>
             <includes>
                 <include>com.github.rlf:uSkyBlock-API</include>
+                <include>ovh.uskyblock:uSkyBlock-APIv2</include>
                 <include>ovh.uskyblock:uSkyBlock-Core</include>
                 <include>ovh.uskyblock:uSkyBlock-FAWE</include>
                 <include>ovh.uskyblock:uSkyBlock-AWE370</include>


### PR DESCRIPTION
Given that our current API is _really_ limited, implemented directly in our main class, et cetera, I'd suggest to move towards a new API, APIv2. I really, REALLY hate breaking API's, especially this drastically, but it might be better to put all major breaking changes in one update and move forwards.

This initial draft PR will start with the first breaking change: changing Maven groupId's. 