### PR TITLE
Update region limits to reflect the new 1.18 world height

### DIFF
--- a/uSkyBlock-AWE370/src/main/java/us/talabrek/ultimateskyblock/handler/asyncworldedit/AWE370Adaptor.java
+++ b/uSkyBlock-AWE370/src/main/java/us/talabrek/ultimateskyblock/handler/asyncworldedit/AWE370Adaptor.java
@@ -111,7 +111,7 @@ public class AWE370Adaptor implements AWEAdaptor {
     public void loadIslandSchematic(final File file, final Location origin, final PlayerPerk playerPerk) {
         final IAsyncWorldEdit awe = getAWE();
         BukkitWorld bukkitWorld = new BukkitWorld(origin.getWorld());
-        int maxBlocks = (255 * Settings.island_protectionRange * Settings.island_protectionRange);
+        int maxBlocks = ((bukkitWorld.getMaxY() - bukkitWorld.getMinY()) * Settings.island_protectionRange * Settings.island_protectionRange);
         IPlayerManager pm = awe.getPlayerManager();
         final IPlayerEntry playerEntry = pm.getUnknownPlayer();
         IThreadSafeEditSession tsSession = (IThreadSafeEditSession) createEditSession(bukkitWorld, maxBlocks);

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/handler/AsyncWorldEditHandler.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/handler/AsyncWorldEditHandler.java
@@ -128,7 +128,7 @@ public enum AsyncWorldEditHandler {;
                 @Override
                 public void run() {
                     try {
-                        final EditSession editSession = WorldEditHandler.createEditSession(region.getWorld(), region.getArea() * 255);
+                        final EditSession editSession = WorldEditHandler.createEditSession(region.getWorld(), (int) region.getVolume());
                         editSession.setReorderMode(EditSession.ReorderMode.MULTI_STAGE);
                         editSession.setSideEffectApplier(SideEffectSet.defaults());
                         editSession.getWorld().regenerate(region, editSession);

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/handler/WorldGuardHandler.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/handler/WorldGuardHandler.java
@@ -214,11 +214,11 @@ public class WorldGuardHandler {
     }
 
     public static BlockVector3 getProtectionVectorLeft(final Location island) {
-        return BlockVector3.at(island.getX() + Settings.island_radius - 1, 255.0, island.getZ() + Settings.island_radius - 1);
+        return BlockVector3.at(island.getX() + Settings.island_radius - 1, 319.0, island.getZ() + Settings.island_radius - 1);
     }
 
     public static BlockVector3 getProtectionVectorRight(final Location island) {
-        return BlockVector3.at(island.getX() - Settings.island_radius, 0.0, island.getZ() - Settings.island_radius);
+        return BlockVector3.at(island.getX() - Settings.island_radius, -64.0, island.getZ() - Settings.island_radius);
     }
 
     public static String getIslandNameAt(Location location) {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/handler/WorldGuardHandler.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/handler/WorldGuardHandler.java
@@ -214,11 +214,13 @@ public class WorldGuardHandler {
     }
 
     public static BlockVector3 getProtectionVectorLeft(final Location island) {
-        return BlockVector3.at(island.getX() + Settings.island_radius - 1, 319.0, island.getZ() + Settings.island_radius - 1);
+        World world = uSkyBlock.getInstance().getWorldManager().getWorld();
+        return BlockVector3.at(island.getX() + Settings.island_radius - 1, world.getMaxHeight(), island.getZ() + Settings.island_radius - 1);
     }
 
     public static BlockVector3 getProtectionVectorRight(final Location island) {
-        return BlockVector3.at(island.getX() - Settings.island_radius, -64.0, island.getZ() - Settings.island_radius);
+        World world = uSkyBlock.getInstance().getWorldManager().getWorld();
+        return BlockVector3.at(island.getX() - Settings.island_radius, world.getMinHeight(), island.getZ() - Settings.island_radius);
     }
 
     public static String getIslandNameAt(Location location) {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/handler/WorldGuardHandler.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/handler/WorldGuardHandler.java
@@ -215,7 +215,7 @@ public class WorldGuardHandler {
 
     public static BlockVector3 getProtectionVectorLeft(final Location island) {
         World world = island.getWorld();
-        return BlockVector3.at(island.getX() + Settings.island_radius - 1, world.getMaxHeight(), island.getZ() + Settings.island_radius - 1);
+        return BlockVector3.at(island.getX() + Settings.island_radius - 1, world.getMaxHeight() - 1, island.getZ() + Settings.island_radius - 1);
     }
 
     public static BlockVector3 getProtectionVectorRight(final Location island) {
@@ -325,7 +325,7 @@ public class WorldGuardHandler {
                 return false;
             }
             World world = islandLocation.getWorld();
-            ProtectedRegion spawn = new ProtectedCuboidRegion("spawn", BlockVector3.at(-r, world.getMinHeight(), -r), BlockVector3.at(r, world.getMaxHeight(), r));
+            ProtectedRegion spawn = new ProtectedCuboidRegion("spawn", BlockVector3.at(-r, world.getMinHeight(), -r), BlockVector3.at(r, world.getMaxHeight() - 1, r));
             ProtectedCuboidRegion islandRegion = getIslandRegion(islandLocation);
             return !islandRegion.getIntersectingRegions(Collections.singletonList(spawn)).isEmpty();
         } catch (Exception e) {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/handler/WorldGuardHandler.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/handler/WorldGuardHandler.java
@@ -214,12 +214,12 @@ public class WorldGuardHandler {
     }
 
     public static BlockVector3 getProtectionVectorLeft(final Location island) {
-        World world = uSkyBlock.getInstance().getWorldManager().getWorld();
+        World world = island.getWorld();
         return BlockVector3.at(island.getX() + Settings.island_radius - 1, world.getMaxHeight(), island.getZ() + Settings.island_radius - 1);
     }
 
     public static BlockVector3 getProtectionVectorRight(final Location island) {
-        World world = uSkyBlock.getInstance().getWorldManager().getWorld();
+        World world = island.getWorld();
         return BlockVector3.at(island.getX() - Settings.island_radius, world.getMinHeight(), island.getZ() - Settings.island_radius);
     }
 
@@ -324,7 +324,8 @@ public class WorldGuardHandler {
             if (r == 0) {
                 return false;
             }
-            ProtectedRegion spawn = new ProtectedCuboidRegion("spawn", BlockVector3.at(-r, 0, -r), BlockVector3.at(r, 255, r));
+            World world = islandLocation.getWorld();
+            ProtectedRegion spawn = new ProtectedCuboidRegion("spawn", BlockVector3.at(-r, world.getMinHeight(), -r), BlockVector3.at(r, world.getMaxHeight(), r));
             ProtectedCuboidRegion islandRegion = getIslandRegion(islandLocation);
             return !islandRegion.getIntersectingRegions(Collections.singletonList(spawn)).isEmpty();
         } catch (Exception e) {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/handler/task/WorldEditClear.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/handler/task/WorldEditClear.java
@@ -74,7 +74,7 @@ public class WorldEditClear extends IncrementalRunnable {
         while (!regions.isEmpty()) {
             final Region region = regions.remove(0);
             final EditSession editSession = WorldEditHandler.createEditSession(
-                    new BukkitWorld(world), region.getArea() * 255);
+                    new BukkitWorld(world), (int) region.getVolume());
             editSession.setReorderMode(EditSession.ReorderMode.MULTI_STAGE);
             editSession.setSideEffectApplier(SideEffectSet.defaults());
             try {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/ChunkSnapshotLevelLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/ChunkSnapshotLevelLogic.java
@@ -65,8 +65,11 @@ public class ChunkSnapshotLevelLogic extends CommonLevelLogic {
         final BlockCountCollection counts = new BlockCountCollection(scoreMap);
         int minX = region.getMinimumPoint().getBlockX();
         int maxX = region.getMaximumPoint().getBlockX();
+        int minY = region.getMinimumPoint().getBlockY();
+        int maxY = region.getMaximumPoint().getBlockY();
         int minZ = region.getMinimumPoint().getBlockZ();
         int maxZ = region.getMaximumPoint().getBlockZ();
+
         for (int x = minX; x <= maxX; ++x) {
             for (int z = minZ; z <= maxZ; ++z) {
                 ChunkSnapshot chunk = getChunkSnapshot(x >> 4, z >> 4, snapshotsOverworld);
@@ -77,7 +80,7 @@ public class ChunkSnapshotLevelLogic extends CommonLevelLogic {
                 }
                 int cx = (x & 0xf);
                 int cz = (z & 0xf);
-                for (int y = 0; y <= 255; y++) {
+                for (int y = minY; y <= maxY; y++) {
                     Material blockType = chunk.getBlockType(cx, y, cz);
                     if (blockType == Material.AIR) {
                         continue;

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/ChunkSnapshotLevelLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/ChunkSnapshotLevelLogic.java
@@ -80,7 +80,7 @@ public class ChunkSnapshotLevelLogic extends CommonLevelLogic {
                 }
                 int cx = (x & 0xf);
                 int cz = (z & 0xf);
-                for (int y = minY; y <= maxY; y++) {
+                for (int y = minY; y < maxY; y++) {
                     Material blockType = chunk.getBlockType(cx, y, cz);
                     if (blockType == Material.AIR) {
                         continue;

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/task/SetBiomeTask.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/task/SetBiomeTask.java
@@ -77,7 +77,7 @@ public class SetBiomeTask extends IncrementalRunnable {
             }
             for (int x = cx; x <= mx; x++) {
                 for (int z = cz; z <= mz; z++) {
-                    for (int y = 0; y < world.getMaxHeight(); y++) {
+                    for (int y = world.getMinHeight(); y < world.getMaxHeight(); y++) {
                         world.setBiome(x, y, z, biome);
                     }
                 }

--- a/uSkyBlock-FAWE/pom.xml
+++ b/uSkyBlock-FAWE/pom.xml
@@ -10,19 +10,24 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>uSkyBlock-FAWE</artifactId>
 
-    <repositories>
-        <repository>
-            <id>IntellectualSites</id>
-            <url>https://mvn.intellectualsites.com/content/repositories/releases/</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>com.fastasyncworldedit</groupId>
-            <artifactId>FAWE-Bukkit</artifactId>
-            <version>1.17-268</version>
+            <artifactId>FastAsyncWorldEdit-Core</artifactId>
+            <version>2.0.1</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fastasyncworldedit</groupId>
+            <artifactId>FastAsyncWorldEdit-Bukkit</artifactId>
+            <version>2.0.1</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>FastAsyncWorldEdit-Core</artifactId>
+                    <groupId>*</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>uSkyBlock</groupId>

--- a/uSkyBlock-FAWE/src/main/java/us/talabrek/ultimateskyblock/handler/asyncworldedit/FAWEAdaptor.java
+++ b/uSkyBlock-FAWE/src/main/java/us/talabrek/ultimateskyblock/handler/asyncworldedit/FAWEAdaptor.java
@@ -1,6 +1,6 @@
 package us.talabrek.ultimateskyblock.handler.asyncworldedit;
 
-import com.fastasyncworldedit.core.util.EditSessionBuilder;
+import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.bukkit.BukkitWorld;
 import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat;
@@ -10,7 +10,6 @@ import com.sk89q.worldedit.regions.Region;
 import com.sk89q.worldedit.world.World;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
 import us.talabrek.ultimateskyblock.player.PlayerPerk;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 
@@ -72,7 +71,7 @@ public class FAWEAdaptor implements AWEAdaptor {
     }
 
     public EditSession createEditSession(World bukkitWorld, int maxBlocks) {
-        return new EditSessionBuilder(bukkitWorld).fastmode(true).build();
+        return WorldEdit.getInstance().newEditSessionBuilder().world(bukkitWorld).fastMode(true).build();
     }
 
     @Override


### PR DESCRIPTION
Some of the players on our server are complaining that they cannot build below Y0 after the new 1.18 update. I briefly looked into the code and found that the minimum and maximum region height values are hard coded to the old world limits. 

I propose to change these values to reflect the new world height limits.


*(moved to uskyblock/uSkyBlock repo as per request https://github.com/rlf/uSkyBlock/pull/1288#issuecomment-1023485736)*