### PR TITLE
Fix biome permissions with new Biome IDs

### DIFF
--- a/uSkyBlock-Core/src/main/resources/challenges.yml
+++ b/uSkyBlock-Core/src/main/resources/challenges.yml
@@ -1055,7 +1055,7 @@ ranks:
           items:
           - DIAMOND:1
           - EMERALD:1
-          permission: usb.biome.swampland
+          permission: usb.biome.swamp
           currency: 70
           xp: 70
         repeatReward:

--- a/uSkyBlock-Core/src/main/resources/plugin.yml
+++ b/uSkyBlock-Core/src/main/resources/plugin.yml
@@ -174,14 +174,14 @@ permissions:
     children:
       usb.biome.deep_ocean: true
       usb.biome.desert: true
-      usb.biome.extreme_hills: true # TODO replace with new biome name
+      usb.biome.windswept_hills: true
       usb.biome.forest: true
-      usb.biome.hell: true # TODO replace with new biome name (probably nether wastes)
+      usb.biome.nether_wastes: true
       usb.biome.jungle: true
       usb.biome.mushroom_fields: true
       usb.biome.ocean: false # default: true
       usb.biome.plains: true
-      usb.biome.sky: true # TODO replace with new biome name (is it the END biome?)
+      usb.biome.the_end: true
       usb.biome.swamp: true
       usb.biome.taiga: true
 
@@ -390,17 +390,17 @@ permissions:
     default: false
     description: 'Let the player change their islands biome to DESERT'
 
-  usb.biome.extreme_hills:
+  usb.biome.windswept_hills:
     default: false
-    description: 'Let the player change their islands biome to EXTREME_HILLS'
+    description: 'Let the player change their islands biome to WINDSWEPT_HILLS'
 
   usb.biome.forest:
     default: false
     description: 'Let the player change their islands biome to FOREST'
 
-  usb.biome.hell:
+  usb.biome.nether_wastes:
     default: false
-    description: 'Let the player change their islands biome to HELL'
+    description: 'Let the player change their islands biome to NETHER_WASTES'
 
   usb.biome.jungle:
     default: false
@@ -418,9 +418,9 @@ permissions:
     default: false
     description: 'Let the player change their islands biome to PLAINS'
 
-  usb.biome.sky:
+  usb.biome.the_end:
     default: false
-    description: 'Let the player change their islands biome to SKY'
+    description: 'Let the player change their islands biome to THE_END'
 
   usb.biome.swamp:
     default: false

--- a/uSkyBlock-Core/src/main/resources/plugin.yml
+++ b/uSkyBlock-Core/src/main/resources/plugin.yml
@@ -174,15 +174,15 @@ permissions:
     children:
       usb.biome.deep_ocean: true
       usb.biome.desert: true
-      usb.biome.extreme_hills: true
+      usb.biome.extreme_hills: true # TODO replace with new biome name
       usb.biome.forest: true
-      usb.biome.hell: true
+      usb.biome.hell: true # TODO replace with new biome name (probably nether wastes)
       usb.biome.jungle: true
-      usb.biome.mushroom: true
+      usb.biome.mushroom_fields: true
       usb.biome.ocean: false # default: true
       usb.biome.plains: true
-      usb.biome.sky: true
-      usb.biome.swampland: true
+      usb.biome.sky: true # TODO replace with new biome name (is it the END biome?)
+      usb.biome.swamp: true
       usb.biome.taiga: true
 
   usb.exempt.*:
@@ -406,9 +406,9 @@ permissions:
     default: false
     description: 'Let the player change their islands biome to JUNGLE'
 
-  usb.biome.mushroom:
+  usb.biome.mushroom_fields:
     default: false
-    description: 'Let the player change their islands biome to MUSHROOM'
+    description: 'Let the player change their islands biome to MUSHROOM_FIELDS'
 
   usb.biome.ocean:
     default: true
@@ -422,9 +422,9 @@ permissions:
     default: false
     description: 'Let the player change their islands biome to SKY'
 
-  usb.biome.swampland:
+  usb.biome.swamp:
     default: false
-    description: 'Let the player change their islands biome to SWAMPLAND'
+    description: 'Let the player change their islands biome to SWAMP'
 
   usb.biome.taiga:
     default: false


### PR DESCRIPTION
USB internally generates the Biome permission nodes based on the enum values in `org.bukkit.block.Biome`.
This enum has probably been updated, thus permissions for specific biomes also needs to be updated in the plugin.

The issue was originally about the `slimefarmer` challenge that was giving the permission `usb.biome.swampland` that doesn’t exists anymore. Now, this PR aims at updating all references to specific biome `usb.biome.*` permissions and rename it to new biome names according to the enum.