### PR TITLE
Don't hijack respawn event in unrelated worlds

### DIFF
--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/event/PlayerEvents.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/event/PlayerEvents.java
@@ -3,6 +3,7 @@ package us.talabrek.ultimateskyblock.event;
 import dk.lockfuglsang.minecraft.util.ItemStackUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Levelled;
@@ -35,6 +36,7 @@ import us.talabrek.ultimateskyblock.player.PatienceTester;
 import us.talabrek.ultimateskyblock.player.PlayerInfo;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 import us.talabrek.ultimateskyblock.util.LocationUtil;
+import us.talabrek.ultimateskyblock.world.WorldManager;
 
 import java.util.*;
 
@@ -254,6 +256,12 @@ public class PlayerEvents implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerRespawn(PlayerRespawnEvent event) {
+        WorldManager wm = plugin.getWorldManager();
+        World pWorld = event.getPlayer().getWorld();
+        if (!wm.isSkyAssociatedWorld(pWorld)) {
+            return;
+        }
+
         if (Settings.extras_respawnAtIsland) {
             PlayerInfo playerInfo = plugin.getPlayerInfo(event.getPlayer());
             if (playerInfo.getHasIsland()) {
@@ -268,7 +276,7 @@ public class PlayerEvents implements Listener {
                 }
             }
         }
-        if (!Settings.extras_sendToSpawn && plugin.getWorldManager().isSkyWorld(event.getPlayer().getWorld())) {
+        if (!Settings.extras_sendToSpawn && wm.isSkyWorld(pWorld)) {
             event.setRespawnLocation(plugin.getWorldManager().getWorld().getSpawnLocation());
         }
     }


### PR DESCRIPTION
Verify the player died in a skyworld before performing teleportation.

Makes respawn behaviour predictable on multi-world servers.

Also fixes a conflict with the MobArena plugin where a player would be teleported on death out of the arena, and their only option would be to `/ma leave` which would unexpectedly delete their skyblock inventory.