### PR TITLE
Merge bukkit utils into main repository

### DIFF
--- a/bukkit-utils/.editorconfig
+++ b/bukkit-utils/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.java]
+end_of_line=lf
+
+[*.json]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.sh]
+end_of_line = lf

--- a/bukkit-utils/.github/workflows/build.yml
+++ b/bukkit-utils/.github/workflows/build.yml
@@ -1,0 +1,48 @@
+name: Maven build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build_and_test:
+    if: github.repository_owner == 'uskyblock'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: JDK 16
+        uses: actions/setup-java@v1
+        with:
+          java-version: '16'
+          distribution: 'adopt'
+      - name: Cache Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build with Maven
+        run: mvn -U clean deploy
+
+      # Deploy steps when pushed to master
+      - name: Install SSH key
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          known_hosts: ${{ secrets.SSH_KNOWN_HOST }}
+      - name: Rsync deploy mvn repo
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        run: |
+          rsync -r --quiet -e "ssh -p 2222 -o StrictHostKeyChecking=no" \
+          target/mvn-repo/ \
+          travis@travis.internetpolice.eu:WWW-USB/maven/uskyblock/
+      - name: Rsync deploy javadocs
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        run: |
+          rsync -r --quiet -e "ssh -p 2222 -o StrictHostKeyChecking=no" \
+          target/site/apidocs \
+          travis@travis.internetpolice.eu:WWW-USB/javadocs/dependencies/bukkit-utils/

--- a/bukkit-utils/.gitignore
+++ b/bukkit-utils/.gitignore
@@ -1,0 +1,4 @@
+/.idea
+**/*.iml
+/target
+deploy_rsa

--- a/bukkit-utils/README.md
+++ b/bukkit-utils/README.md
@@ -1,0 +1,48 @@
+# bukkit-utils
+
+This module holds general Bukkit Utilities enabling easier Bukkit Plugin creation.
+
+## Utilities
+
+* [FileUtil](src/main/java/dk/lockfuglsang/minecraft/file/README.md) - UTF-8, Locale and merging config files from jar
+* [YmlConfiguration](src/main/java/dk/lockfuglsang/minecraft/yml/README.md) - Support for comments in yml-files
+* [Commands](src/main/java/dk/lockfuglsang/minecraft/command/README.md) - Framework for easy command-creation
+
+# License
+
+This module is copyrighted by the authors, and licensed for re-use as Apache License 2.0.
+
+# Usage
+
+Put this in your `pom.xml`:
+
+```
+  <repositories>
+    <repository>
+        <id>uSkyBlock-mvn-repo</id>
+        <url>https://raw.github.com/rlf/mvn-repo/master</url>
+    </repository>
+  </repositories>
+  <dependencies>
+    <dependency>
+        <groupId>dk.lockfuglsang.minecraft</groupId>
+        <artifactId>bukkit-utils</artifactId>
+        <version>1.22</version>
+    </dependency>
+  </dependencies>
+```
+
+# Version History
+
+## 1.22 - Bukkit 1.13 compatible
+
+## 1.21 - Bukkit 1.12 compatible
+
+## v1.1
+
+* FileUtil, I18nUtil
+
+## v1.0
+Initial release, extracted from the source-code used in uSkyBlock
+
+* YmlConfiguration, Commands

--- a/bukkit-utils/pom.xml
+++ b/bukkit-utils/pom.xml
@@ -4,13 +4,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>dk.lockfuglsang.minecraft</groupId>
+    <parent>
+        <artifactId>uSkyBlock</artifactId>
+        <groupId>ovh.uskyblock</groupId>
+        <version>3.1.0-SNAPSHOT</version>
+    </parent>
     <artifactId>bukkit-utils</artifactId>
-    <version>1.25-SNAPSHOT</version>
 
     <properties>
-        <poutils.version>1.2</poutils.version>
-        <spigotapi.version>1.17-R0.1-SNAPSHOT</spigotapi.version>
         <vaultapi.version>1.7</vaultapi.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -107,9 +108,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>dk.lockfuglsang.minecraft</groupId>
+            <groupId>ovh.uskyblock</groupId>
             <artifactId>po-utils</artifactId>
-            <version>${poutils.version}</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>

--- a/bukkit-utils/pom.xml
+++ b/bukkit-utils/pom.xml
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>dk.lockfuglsang.minecraft</groupId>
+    <artifactId>bukkit-utils</artifactId>
+    <version>1.25-SNAPSHOT</version>
+
+    <properties>
+        <poutils.version>1.2</poutils.version>
+        <spigotapi.version>1.17-R0.1-SNAPSHOT</spigotapi.version>
+        <vaultapi.version>1.7</vaultapi.version>
+
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <scm>
+        <connection>scm:git:git://github.com/uskyblock/bukkit-utils.git</connection>
+        <developerConnection>scm:git:git://github.com/uskyblock/bukkit-utils.git</developerConnection>
+        <url>https://github.com/uskyblock/bukkit-utils.git</url>
+    </scm>
+
+    <distributionManagement>
+        <repository>
+            <id>internal.repo</id>
+            <name>Temporary Staging Repository</name>
+            <url>file://${project.build.directory}/mvn-repo</url>
+        </repository>
+    </distributionManagement>
+
+    <repositories>
+        <repository>
+            <id>spigotmc.org</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/public</url>
+        </repository>
+        <repository> <!-- uSkyBlock dependencies that don't have a (stable) repository -->
+            <id>uskyblock-dependencies</id>
+            <url>https://www.uskyblock.ovh/maven/dependencies/</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>apache-snapshots</id>
+            <url>https://repository.apache.org/snapshots/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <release>16</release>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <show>public</show>
+                    <failOnError>false</failOnError>
+                    <doclint>none</doclint>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>javadoc</goal>
+                        </goals>
+                        <phase>deploy</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>dk.lockfuglsang.minecraft</groupId>
+            <artifactId>po-utils</artifactId>
+            <version>${poutils.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>${spigotapi.version}</version>
+            <optional>true</optional>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.milkbowl.vault</groupId>
+            <artifactId>VaultAPI</artifactId>
+            <version>${vaultapi.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <!-- DEPRECATED -->
+<!--        <dependency>-->
+<!--            <groupId>com.googlecode.json-simple</groupId>-->
+<!--            <artifactId>json-simple</artifactId>-->
+<!--            <version>1.1.1</version>-->
+<!--            <scope>test</scope>-->
+<!--        </dependency>-->
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.28.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.7</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/animation/Animation.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/animation/Animation.java
@@ -1,0 +1,14 @@
+package dk.lockfuglsang.minecraft.animation;
+
+import org.bukkit.entity.Player;
+
+/**
+ * Common interface for animations
+ */
+public interface Animation {
+    boolean show();
+
+    boolean hide();
+
+    Player getPlayer();
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/animation/AnimationHandler.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/animation/AnimationHandler.java
@@ -1,0 +1,116 @@
+package dk.lockfuglsang.minecraft.animation;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Handles particles and per-player block-animations
+ */
+public class AnimationHandler {
+    private final Map<UUID, Set<Animation>> animations = new ConcurrentHashMap<>();
+    private final Map<UUID, AnimationTask> animationTasks = new ConcurrentHashMap<>();
+    private final Plugin plugin;
+
+    private int animTick;
+
+    public AnimationHandler(Plugin plugin) {
+        this.plugin = plugin;
+        animTick = plugin.getConfig().getInt("animations.tick", 20);
+    }
+
+    public void setAnimTick(int animTick) {
+        this.animTick = animTick;
+        plugin.getConfig().set("animations.tick", animTick);
+    }
+
+    public synchronized void addAnimation(Animation animation) {
+        if (!animations.containsKey(animation.getPlayer().getUniqueId())) {
+            animations.put(animation.getPlayer().getUniqueId(), new HashSet<Animation>());
+        }
+        animations.get(animation.getPlayer().getUniqueId()).add(animation);
+        start();
+    }
+
+    public synchronized boolean removeAnimations(Player player) {
+        Set<Animation> animSet = animations.remove(player.getUniqueId());
+        if (animSet == null) {
+            return false;
+        }
+        for (Animation animation : animSet) {
+            animation.hide();
+        }
+        return true;
+    }
+
+    public synchronized void start() {
+        for (UUID uuid : animations.keySet()) {
+            AnimationTask animationTask = animationTasks.get(uuid);
+            if (animationTask == null && animations.get(uuid) != null && !animations.get(uuid).isEmpty()) {
+                animationTask = new AnimationTask(uuid);
+                animationTask.runTaskTimerAsynchronously(plugin, 0, animTick);
+                animationTasks.put(uuid, animationTask);
+            }
+        }
+    }
+
+    public synchronized void stop() {
+        for (UUID uuid :  animations.keySet()) {
+            AnimationTask animationTask = animationTasks.get(uuid);
+            if (animationTask != null) {
+                animationTask.cancel();
+                animationTasks.remove(uuid);
+            }
+        }
+        if (plugin.isEnabled()) {
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, new Runnable() {
+                @Override
+                public void run() {
+                    Collection<Set<Animation>> anims = new ArrayList<>(animations.values());
+                    for (Set<Animation> animSet : anims) {
+                        for (Animation animation : animSet) {
+                            animation.hide();
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    private class AnimationTask extends BukkitRunnable {
+        private final UUID uniqueId;
+        public AnimationTask(UUID uniqueId) {
+            this.uniqueId = uniqueId;
+        }
+
+        @Override
+        public void run() {
+            // Copy - to avoid ConcurrentModificationException
+            Set<Animation> animSet = animations.get(uniqueId);
+            Set<Animation> animCopy = (animSet != null) ? new HashSet<>(animSet) : Collections.<Animation>emptySet();
+            for (Animation animation : animCopy) {
+                if (!animation.show()) {
+                    UUID uuid = animation.getPlayer().getUniqueId();
+                    animations.get(uuid).remove(animation);
+                    if (animations.get(uuid).isEmpty()) {
+                        animations.remove(uuid);
+                    }
+                }
+            }
+            if (animations.get(uniqueId) == null) {
+                cancel();
+                animationTasks.remove(uniqueId);
+            }
+        }
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/animation/BlockAnimation.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/animation/BlockAnimation.java
@@ -1,0 +1,65 @@
+package dk.lockfuglsang.minecraft.animation;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+/**
+ * Sends (bogus) block-info to the player
+ */
+public class BlockAnimation implements Animation {
+    private final Player player;
+    private final List<Location> points;
+    private final Material material;
+    private final byte data;
+    private volatile boolean shown;
+
+    public BlockAnimation(Player player, List<Location> points, Material material, byte data) {
+        this.player = player;
+        this.points = points;
+        this.material = material;
+        this.data = data;
+        shown = false;
+    }
+
+    @Override
+    public boolean show() {
+        if (shown) {
+            return true;
+        }
+        if (!player.isOnline()) {
+            return false;
+        }
+        for (Location loc : points) {
+            if (!PlayerHandler.sendBlockChange(player, loc, material, data)) {
+                return false;
+            }
+        }
+        shown = true;
+        return true;
+    }
+
+    @Override
+    public boolean hide() {
+        try {
+            if (shown) {
+                for (Location loc : points) {
+                    if (!PlayerHandler.sendBlockChange(player, loc, loc.getBlock().getType(), loc.getBlock().getData())) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
+        } finally {
+            shown = false;
+        }
+    }
+
+    @Override
+    public Player getPlayer() {
+        return player;
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/animation/ParticleAnimation.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/animation/ParticleAnimation.java
@@ -1,0 +1,47 @@
+package dk.lockfuglsang.minecraft.animation;
+
+import org.bukkit.Location;
+import org.bukkit.Particle;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+
+/**
+ * An animation using particles (requires refreshes).
+ */
+public class ParticleAnimation implements Animation {
+    private final Player player;
+    private final Particle particle;
+    private final List<Location> points;
+    private final int animCount;
+
+    public ParticleAnimation(Player player, List<Location> points, Particle particle, int animCount) {
+        this.player = player;
+        this.particle = particle;
+        this.points = points;
+        this.animCount = animCount;
+    }
+
+    @Override
+    public boolean show() {
+        if (!player.isOnline()) {
+            return false;
+        }
+        for (Location loc : points) {
+            if (!PlayerHandler.spawnParticle(player, particle, loc, animCount)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean hide() {
+        return true;
+    }
+
+    @Override
+    public Player getPlayer() {
+        return player;
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/animation/PlayerHandler.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/animation/PlayerHandler.java
@@ -1,0 +1,61 @@
+package dk.lockfuglsang.minecraft.animation;
+
+import org.bukkit.Effect;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Particle;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+
+/**
+ * Common handler across servers for sending particles and other packages to a player.
+ */
+public enum PlayerHandler {;
+    private static final Logger log = Logger.getLogger(PlayerHandler.class.getName());
+
+    public static boolean spawnParticle(Player player, Particle particle, Location loc, int count) {
+        try {
+            Method playMethod = getMethod(player, "spawnParticle", new Class<?>[]{Particle.class, Location.class, Integer.TYPE});
+            if (playMethod != null) {
+                playMethod.invoke(player, particle, loc, count);
+                return true;
+            }
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            log.finest("Unable to spawnParticle for player " + player + ": " + e);
+        }
+        return false;
+    }
+
+    public static boolean sendBlockChange(Player player, Location location, Material material, byte data) {
+        try {
+            Method method = getMethod(player, "sendBlockChange", new Class<?>[]{Location.class, Material.class, Byte.TYPE});
+            if (method != null) {
+                method.invoke(player, location, material, data);
+                return true;
+            }
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            log.finest("Unable to sendBlockChange to player " + player + ": " + e);
+        }
+        return false;
+    }
+
+    public static boolean playEffect(Player player, Location loc, Effect effect, int data) {
+        try {
+            Method playMethod = getMethod(player, "playEffect", new Class<?>[]{Location.class, Effect.class, Integer.TYPE});
+            if (playMethod != null) {
+                playMethod.invoke(player, loc, effect, data);
+                return true;
+            }
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            log.finest("Unable to playEffect for player " + player + ": " + e);
+        }
+        return false;
+    }
+
+    private static Method getMethod(Object player, String methodName, Class<?>[] paramClasses) throws NoSuchMethodException {
+        return player.getClass().getMethod(methodName, paramClasses);
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/AbstractCommand.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/AbstractCommand.java
@@ -1,0 +1,141 @@
+package dk.lockfuglsang.minecraft.command;
+
+import dk.lockfuglsang.minecraft.po.I18nUtil;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Convenience implementation of the Command
+ */
+public abstract class AbstractCommand implements Command {
+    private final String[] aliases;
+    private final String permission;
+    private final String description;
+    private final String usage;
+    private final String[] params;
+    private CompositeCommand parent;
+    private final Map<String, String> featurePerms = new HashMap<>();
+    private final Set<UUID> permissionOverride;
+
+    public AbstractCommand(String name, String permission, String params, String description, String usage, UUID... permissionOverride) {
+        this.aliases = name.split("\\|");
+        this.permission = permission;
+        this.description = I18nUtil.tr(description);
+        this.usage = I18nUtil.tr(usage);
+        this.params = params != null && !params.trim().isEmpty() ? params.split(" ") : new String[0];
+        this.permissionOverride = new HashSet<>(Arrays.asList(permissionOverride));
+    }
+
+    public AbstractCommand(String name, String permission, String params, String description) {
+        this(name, permission, params, description, null);
+    }
+
+    public AbstractCommand(String name, String permission, String description) {
+        this(name, permission, null, description, null);
+    }
+
+    public AbstractCommand(String name, String description) {
+        this(name, null, null, description, null);
+    }
+
+    @Override
+    public String getName() {
+        return aliases[0];
+    }
+
+    public String[] getAliases() {
+        return aliases;
+    }
+
+    @Override
+    public String getPermission() {
+        return permission;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String getUsage() {
+        return usage;
+    }
+
+    @Override
+    public String[] getParams() {
+        return params;
+    }
+
+    @Override
+    public TabCompleter getTabCompleter() {
+        return null;
+    }
+
+    @Override
+    public CompositeCommand getParent() {
+        return parent;
+    }
+
+    @Override
+    public void setParent(CompositeCommand parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public void accept(CommandVisitor visitor) {
+        if (visitor != null) {
+            visitor.visit(this);
+        }
+    }
+
+    public void addFeaturePermission(String perm, String description) {
+        featurePerms.put(perm, description);
+    }
+
+    @Override
+    public Map<String, String> getFeaturePermissions() {
+        return Collections.unmodifiableMap(featurePerms);
+    }
+
+    /**
+     * Convenience method until we can fully rely on everybody running JRE 8.
+     * @param args  A list of arguments
+     * @param delim Delimiter to join them
+     * @return A string containing the arguments concatenated.
+     */
+    public static String join(String[] args, String delim) {
+        String res = "";
+        if (args != null && args.length > 0) {
+            for (String arg : args) {
+                res += (res.isEmpty() ? "" : delim) + arg;
+            }
+        }
+        return res;
+    }
+
+    public static String join(String[] args) {
+        return join(args, " ");
+    }
+
+    public boolean hasPermissionOverride(CommandSender sender) {
+        if (sender instanceof Player) {
+            return permissionOverride.contains(((Player) sender).getUniqueId()) || (parent != null && parent.hasPermissionOverride(sender));
+        }
+        return false;
+    }
+
+    @Override
+    public boolean hasPermission(CommandSender sender, String permission) {
+        return hasPermissionOverride(sender) || sender.hasPermission(permission);
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/BaseCommandExecutor.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/BaseCommandExecutor.java
@@ -1,0 +1,46 @@
+package dk.lockfuglsang.minecraft.command;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+import static dk.lockfuglsang.minecraft.po.I18nUtil.tr;
+
+/**
+ * Command delegator.
+ */
+public class BaseCommandExecutor extends CompositeCommand implements CommandExecutor {
+
+    public BaseCommandExecutor(String name, String permission, String description) {
+        super(name, permission, description);
+    }
+
+    public BaseCommandExecutor(String name, String permission, String params, String description) {
+        super(name, permission, params, description);
+    }
+    public BaseCommandExecutor(String name, String permission, String params, String description, UUID... permissionOverrides) {
+        super(name, permission, params, description, permissionOverrides);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String alias, String[] args) {
+        if (!CommandManager.isRequirementsMet(sender, this, args)) {
+            return true;
+        }
+        dk.lockfuglsang.minecraft.command.Command cmd = this;
+        if (!hasAccess(cmd, sender)) {
+            if (cmd != null) {
+                sender.sendMessage(tr("\u00a7eYou do not have access (\u00a74{0}\u00a7e)", cmd.getPermission()));
+            } else {
+                sender.sendMessage(tr("\u00a7eInvalid command: {0}", alias));
+            }
+            showUsage(sender, 1);
+        } else {
+            return execute(sender, alias, new HashMap<String, Object>(), args);
+        }
+        return true;
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/Command.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/Command.java
@@ -1,0 +1,89 @@
+package dk.lockfuglsang.minecraft.command;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+
+import java.util.Map;
+
+/**
+ * An abstraction for supporting nesting of commands.
+ * This is a light-weight version of the BukkitCommand abstraction.
+ */
+public interface Command {
+    /**
+     * Returns the name of the sub-command.
+     */
+    String getName();
+
+    /**
+     * The permission of the command. Can be <code>null</code>.
+     */
+    String getPermission();
+
+    /**
+     * A short description of the sub-command.
+     * Used when listing the commands with others.
+     */
+    String getDescription();
+
+    /**
+     * A more verbatim description of the command.
+     * Used when <code>/command help</code> is executed.
+     */
+    String getUsage();
+
+    /**
+     * The list of parameters accepted by the command.
+     * Can be empty, not <code>null</code>.
+     */
+    String[] getParams();
+
+    /**
+     * Returns aliases for the command.
+     * Can be empty, cannot be <code>null</code>.
+     */
+    String[] getAliases();
+
+    /**
+     * Executes the command.
+     */
+    boolean execute(CommandSender sender, String alias, Map<String, Object> data, String... args);
+
+    /**
+     * Optional TabCompleter to override the default ones.
+     * Can be <code>null</code>
+     */
+    TabCompleter getTabCompleter();
+
+    /**
+     * Returns the parent command (if one such is available).
+     * May return <code>null</code>.
+     */
+    CompositeCommand getParent();
+
+    /**
+     * Assigns a parent command.
+     * @param parent
+     */
+    void setParent(CompositeCommand parent);
+
+    /**
+     * Visitor pattern.
+     * @param visitor A visitor for this node.
+     */
+    void accept(CommandVisitor visitor);
+
+    /**
+     * Returns a map of feature-toggling permissions supporte by this command.
+     * @return A map of permission-node as key, and description as value.
+     */
+    Map<String,String> getFeaturePermissions();
+
+    /**
+     * Allows for other than permission checking
+     * @param sender     The commandSender requesting permission
+     * @param permission The permission
+     * @return <code>true</code> if the sender can execute this command
+     */
+    boolean hasPermission(CommandSender sender, String permission);
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/CommandComparator.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/CommandComparator.java
@@ -1,0 +1,13 @@
+package dk.lockfuglsang.minecraft.command;
+
+import java.util.Comparator;
+
+/**
+ * Comparator for sorting sub-commands
+ */
+public class CommandComparator implements Comparator<Command> {
+    @Override
+    public int compare(Command o1, Command o2) {
+        return o1.getName().compareTo(o2.getName());
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/CommandManager.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/CommandManager.java
@@ -1,0 +1,31 @@
+package dk.lockfuglsang.minecraft.command;
+
+import org.bukkit.command.CommandSender;
+
+/**
+ * Static singleton manager for controlling common requirements.
+ */
+public enum CommandManager {;
+    private static RequirementChecker checker;
+
+    public static void registerRequirements(RequirementChecker reqs) {
+        checker = reqs;
+    }
+
+    public static boolean isRequirementsMet(CommandSender sender, Command command, String... args) {
+        if (checker != null) {
+            return checker.isRequirementsMet(sender, command, args);
+        }
+        return true;
+    }
+
+    public interface RequirementChecker {
+        /**
+         * Checks whether the requirements for the command has been met.
+         * @param sender A sender to send detailed feedback to.
+         * @param args
+         * @return <code>true</code> iff the command can proceed.
+         */
+        boolean isRequirementsMet(CommandSender sender, Command command, String... args);
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/CommandVisitor.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/CommandVisitor.java
@@ -1,0 +1,8 @@
+package dk.lockfuglsang.minecraft.command;
+
+/**
+ * Simple visitor for the USBCommands
+ */
+public interface CommandVisitor {
+    void visit(Command cmd);
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/CompositeCommand.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/CompositeCommand.java
@@ -1,0 +1,365 @@
+package dk.lockfuglsang.minecraft.command;
+
+import dk.lockfuglsang.minecraft.command.completion.AbstractTabCompleter;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static dk.lockfuglsang.minecraft.po.I18nUtil.tr;
+
+/**
+ * Command with nested commandMap inside.
+ */
+public class CompositeCommand extends AbstractTabCompleter implements Command, TabCompleter {
+
+    public static final String HELP_PATTERN = "(?iu)help|\\?";
+    private static final int MAX_PER_PAGE = 10;
+
+    private final String name;
+    private final String[] aliases;
+    private final String permission;
+    private final String description;
+    private final String[] params;
+    private CompositeCommand parent;
+    private final Map<String, Command> commandMap;
+    private final Map<String, Command> aliasMap;
+    private final Map<String, TabCompleter> tabMap;
+    private final Map<String, String> featurePerms;
+    private final Set<UUID> permissionOverride;
+
+    public CompositeCommand(String name, String permission, String description) {
+        this(name, permission, null, description);
+    }
+
+    public CompositeCommand(String name, String permission, String params, String description, UUID... permissionOverride) {
+        this.aliases = name.split("\\|");
+        this.name = aliases[0];
+        this.permission = permission;
+        this.description = description;
+        this.params = params != null ? params.split(" ") : new String[0];
+        commandMap = new HashMap<>();
+        aliasMap = new HashMap<>();
+        tabMap = new HashMap<>();
+        featurePerms = new HashMap<>();
+        this.permissionOverride = new HashSet<>(Arrays.asList(permissionOverride));
+    }
+
+    public CompositeCommand add(Command... cmds) {
+        for (Command cmd : cmds) {
+            commandMap.put(cmd.getName(), cmd);
+            for (String alias : cmd.getAliases()) {
+                aliasMap.put(alias, cmd);
+            }
+            cmd.setParent(this);
+        }
+        return this;
+    }
+
+    public CompositeCommand addTab(String arg, TabCompleter tab) {
+        tabMap.put(arg, tab);
+        return this;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String[] getAliases() {
+        return aliases;
+    }
+
+    @Override
+    public String getPermission() {
+        return permission != null && !permission.isEmpty() ? permission : null;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String getUsage() {
+        return null;
+    }
+
+    @Override
+    public String[] getParams() {
+        return params;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String alias, Map<String, Object> data, String... args) {
+        if (!CommandManager.isRequirementsMet(sender, this, args)) {
+            return true;
+        }
+        if (args.length == 0 || (args.length == 1 && args[0].matches(HELP_PATTERN))) {
+            showUsage(sender, 1);
+        } else if (args.length > 1 && args[0].matches(HELP_PATTERN)) {
+            showUsage(sender, args[1]);
+        } else if (args.length > params.length && hasAccess(this, sender)) {
+            String cmdName = args[params.length].toLowerCase();
+            Command cmd = aliasMap.get(cmdName);
+            String[] subArgs = new String[args.length - 1 - params.length];
+            System.arraycopy(args, 1 + params.length, subArgs, 0, subArgs.length);
+            int ix = 0;
+            for (String p : params) {
+                data.put(p, args[ix++]);
+            }
+            if (!hasAccess(cmd, sender)) {
+                if (cmd != null) {
+                    sender.sendMessage(tr("\u00a7eYou do not have access (\u00a74{0}\u00a7e)", cmd.getPermission()));
+                } else {
+                    sender.sendMessage(tr("\u00a7eInvalid command: {0}", cmdName));
+                }
+                showUsage(sender, args[0]);
+            } else if (!cmd.execute(sender, cmdName, data, subArgs)) {
+                showUsage(sender, args[0]);
+            }
+        } else {
+            showUsage(sender, 1);
+        }
+        return true;
+    }
+
+    public void showUsage(CommandSender sender, int page) {
+        String msg = tr("\u00a77Usage: {0}", getShortDescription(sender, this));
+        if (!hasAccess(this, sender)) {
+            sender.sendMessage(msg.split("\n"));
+            return;
+        }
+        if (getUsage() != null && !getUsage().isEmpty()) {
+            msg += "\u00a77" + getUsage();
+        }
+        List<String> cmds = new ArrayList<>(commandMap.keySet());
+        Collections.sort(cmds);
+        cmds = cmds.stream().filter(f -> hasAccess(commandMap.get(f), sender)).collect(Collectors.toList());
+        int realPage = 0;
+        int maxPage = 0;
+        if (cmds.size() > MAX_PER_PAGE) {
+            msg = msg.substring(0, msg.length() - 1); // Remove \n
+            maxPage = (int) Math.round(Math.ceil(cmds.size() * 1f / MAX_PER_PAGE));
+            realPage = Math.max(1, Math.min(maxPage, page));
+            msg += " \u00a77[" + realPage + "/" + maxPage + "]\n";
+            cmds = cmds.subList((realPage - 1) * MAX_PER_PAGE, Math.min(realPage * MAX_PER_PAGE, cmds.size()));
+        }
+        for (String key : cmds) {
+            Command cmd = commandMap.get(key);
+            if (hasAccess(cmd, sender)) {
+                msg += "  " + getShortDescription(sender, cmd);
+            }
+        }
+        if (realPage > 0 && maxPage > realPage) {
+            msg += tr("\u00a77Use \u00a73/{0} ? {1}\u00a77 to display next page\n", getName(), (realPage + 1));
+        } else if (realPage > 0 && maxPage == realPage) {
+            msg += tr("\u00a77Use \u00a73/{0} ? {1} \u00a77 to display previous page\n", getName(), (realPage - 1));
+        }
+        sender.sendMessage(msg.split("\n"));
+    }
+
+    protected void showUsage(CommandSender sender, String arg) {
+        String cmdName = arg.toLowerCase();
+        Command cmd = cmdName.isEmpty() ? this : aliasMap.get(cmdName);
+        if (cmd != null && hasAccess(cmd, sender)) {
+            String msg = tr("\u00a77Usage: {0}", name) + " \u00a7e";
+            msg += getShortDescription(sender, cmd);
+            if (cmd.getUsage() != null && !cmd.getUsage().isEmpty()) {
+                msg += "\u00a77" + cmd.getUsage();
+            }
+            sender.sendMessage(msg.split("\n"));
+        } else if (cmdName.matches("[0-9]+")) {
+            showUsage(sender, Integer.parseInt(cmdName));
+        } else {
+            List<String> cmds = filter(new ArrayList<>(aliasMap.keySet()), cmdName);
+            if (cmds.isEmpty()) {
+                showUsage(sender, 1);
+            } else {
+                String msg = tr("\u00a77Usage: {0}", getShortDescription(sender, this));
+                if (hasAccess(this, sender)) {
+                    for (String key : cmds) {
+                        Command scmd = commandMap.get(key);
+                        if (scmd != null && hasAccess(scmd, sender)) {
+                            msg += "  " + getShortDescription(sender, scmd);
+                        }
+                    }
+                }
+                sender.sendMessage(msg.split("\n"));
+            }
+        }
+    }
+
+    private String getShortDescription(CommandSender sender, Command cmd) {
+        String msg = "\u00a73" + cmd.getName();
+        String[] aliases = cmd.getAliases();
+        if (aliases.length > 1) {
+            msg += "\u00a77";
+            for (int i = 1; i < aliases.length; i++) {
+                msg += " | " + aliases[i];
+            }
+        }
+        msg += "\u00a7a";
+        msg += getParamsAsString(cmd);
+        if (cmd instanceof CompositeCommand) {
+            msg += " [command|help]";
+        }
+        msg += "\u00a77 - \u00a7e";
+        msg += cmd.getDescription();
+        if (sender.isOp() && cmd.getPermission() != null) {
+            msg += " \u00a7c(" + cmd.getPermission() + ")";
+        }
+        msg += "\n";
+        return msg;
+    }
+
+    public static String getParamsAsString(Command cmd) {
+        String msg = "";
+        for (String param : cmd.getParams()) {
+            if (param.startsWith("?")) {
+                msg += " [" + param.substring(1) + "]";
+            } else {
+                msg += " <" + param + ">";
+            }
+        }
+        return msg;
+    }
+
+    public boolean hasAccess(Command cmd, CommandSender sender) {
+        return cmd != null && (cmd.getPermission() == null || cmd.hasPermission(sender, cmd.getPermission()));
+    }
+
+    @Override
+    protected List<String> getTabList(CommandSender commandSender, String term) {
+        ArrayList<String> strings = new ArrayList<>();
+        if (!hasAccess(this, commandSender)) {
+            return strings;
+        }
+        for (Command cmd : commandMap.values()) {
+            if (hasAccess(cmd, commandSender)) {
+                strings.addAll(Arrays.asList(cmd.getAliases()));
+            }
+        }
+        strings.add("help");
+        return strings;
+    }
+
+    protected TabCompleter getTabCompleter(Command cmd, int argNum) {
+        argNum = argNum >= 0 ? argNum : 0;
+        if (cmd.getParams().length > argNum) {
+            String paramName = cmd.getParams()[argNum];
+            if (paramName != null && paramName.startsWith("?")) {
+                paramName = paramName.substring(1);
+            }
+            if (tabMap.containsKey(paramName)) {
+                return tabMap.get(paramName);
+            } else if (getParent() != null) {
+                TabCompleter tab = getParent().getTabCompleter(cmd, argNum);
+                if (tab != null) {
+                    return tab;
+                }
+            }
+        }
+        if (cmd.getTabCompleter() != null) {
+            return cmd.getTabCompleter();
+        }
+        return null;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, org.bukkit.command.Command command, String alias, String[] args) {
+        if (args.length <= params.length && args.length > 0) {
+            TabCompleter tab = getTabCompleter(this, args.length - 1);
+            if (tab != null && tab != this) {
+                return tab.onTabComplete(sender, command, alias, args);
+            } else if (tab == this) {
+                return getTabList(sender, args[args.length - 1]);
+            }
+        } else if (args.length > params.length + 1) { // Sub-commands
+            String cmdName = args[params.length].toLowerCase();
+            Command cmd = aliasMap.get(cmdName);
+            if (cmd != null && (args.length - params.length) > 1) { // Go deeper
+                String[] subArgs = new String[args.length - 1 - params.length];
+                System.arraycopy(args, 1 + params.length, subArgs, 0, subArgs.length);
+                TabCompleter tab = getTabCompleter(cmd, subArgs.length - 1);
+                if (tab != null) {
+                    return tab.onTabComplete(sender, command, alias, subArgs);
+                }
+            } else {
+                return super.onTabComplete(sender, command, alias, args);
+            }
+        } else {
+            return super.onTabComplete(sender, command, alias, args);
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public TabCompleter getTabCompleter() {
+        return this;
+    }
+
+    @Override
+    public CompositeCommand getParent() {
+        return parent;
+    }
+
+    @Override
+    public void setParent(CompositeCommand parent) {
+        this.parent = parent;
+    }
+
+    public List<Command> getChildren() {
+        ArrayList<Command> list = new ArrayList<>(commandMap.values());
+        Collections.sort(list, new CommandComparator());
+        return Collections.unmodifiableList(list);
+    }
+
+    @Override
+    public void accept(CommandVisitor visitor) {
+        if (visitor != null) {
+            visitor.visit(this);
+            for (Command child : getChildren()) {
+                child.accept(visitor);
+            }
+        }
+    }
+
+    public void addFeaturePermission(String perm, String description) {
+        featurePerms.put(perm, description);
+    }
+
+    @Override
+    public Map<String, String> getFeaturePermissions() {
+        return Collections.unmodifiableMap(featurePerms);
+    }
+
+    private boolean hasPermissionOverride(UUID uuid) {
+        return permissionOverride.contains(uuid) || (getParent() != null && getParent().hasPermissionOverride(uuid));
+    }
+
+    public boolean hasPermissionOverride(CommandSender sender) {
+        if (sender instanceof Player) {
+            return hasPermissionOverride(((Player) sender).getUniqueId());
+        }
+        return false;
+    }
+
+    public boolean hasPermission(CommandSender sender, String permission) {
+        if (sender instanceof Player) {
+            return hasPermissionOverride(((Player) sender).getUniqueId()) || sender.hasPermission(permission);
+        }
+        return sender.hasPermission(permission);
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/DocumentCommand.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/DocumentCommand.java
@@ -1,0 +1,79 @@
+package dk.lockfuglsang.minecraft.command;
+
+import dk.lockfuglsang.minecraft.command.completion.AbstractTabCompleter;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static dk.lockfuglsang.minecraft.po.I18nUtil.marktr;
+import static dk.lockfuglsang.minecraft.po.I18nUtil.tr;
+
+/**
+ * Command that traverses all the commands in a plugin, and generates documentation for them.
+ */
+public class DocumentCommand extends AbstractCommand {
+    public static final List<String> FORMATS = Arrays.asList("text", "yml");
+    private final JavaPlugin plugin;
+    private TabCompleter tabCompleter;
+
+    public DocumentCommand(JavaPlugin plugin, String name, String permission) {
+        super(name, permission, "?format ?arg", marktr("saves documentation of the commands to a file"));
+        this.plugin = plugin;
+        tabCompleter = new AbstractTabCompleter() {
+            @Override
+            protected List<String> getTabList(CommandSender commandSender, String term) {
+                return FORMATS;
+            }
+        };
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String alias, Map<String, Object> data, String... args) {
+        if (args.length == 0 || args[0].equalsIgnoreCase("text")) {
+            int lineWidth = args.length > 1 && args[1].matches("\\d+") ? Integer.parseInt(args[1], 10) : 130;
+            return writeToFile(sender, new PlainTextCommandVisitor(lineWidth), getName() + ".txt");
+        } else if (args[0].equalsIgnoreCase("yml")) {
+            int groupDepth = args.length > 1 && args[1].matches("\\d+") ? Integer.parseInt(args[1], 10) : 2;
+            return writeToFile(sender, new PluginYamlCommandVisitor(groupDepth), getName() + ".yml");
+        }
+        return false;
+    }
+
+    private boolean writeToFile(CommandSender sender, DocumentWriter visitor, String filename) {
+        List<String> commands = new ArrayList<>(plugin.getDescription().getCommands().keySet());
+        Collections.sort(commands);
+        for (String cmd : commands) {
+            PluginCommand pluginCommand = plugin.getCommand(cmd);
+            if (pluginCommand.getExecutor() instanceof Command) {
+                ((Command) pluginCommand.getExecutor()).accept(visitor);
+            }
+        }
+        File docFile = new File(plugin.getDataFolder(), filename);
+        try (FileOutputStream fos = new FileOutputStream(docFile);
+             PrintStream ps = new PrintStream(fos, true, "UTF-8"))
+        {
+            visitor.writeTo(ps);
+            sender.sendMessage(tr("Wrote documentation to {0}", docFile));
+            return true;
+        } catch (IOException e) {
+            sender.sendMessage(tr("\u00a74Error writing documentation: {0}", e.getMessage()));
+        }
+        return false;
+    }
+
+    @Override
+    public TabCompleter getTabCompleter() {
+        return tabCompleter;
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/DocumentWriter.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/DocumentWriter.java
@@ -1,0 +1,10 @@
+package dk.lockfuglsang.minecraft.command;
+
+import java.io.PrintStream;
+
+/**
+ * Common interface for the DocumentCommand-visitors
+ */
+public interface DocumentWriter extends CommandVisitor {
+    void writeTo(PrintStream ps);
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/LanguageCommand.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/LanguageCommand.java
@@ -1,0 +1,64 @@
+package dk.lockfuglsang.minecraft.command;
+
+import dk.lockfuglsang.minecraft.po.I18nUtil;
+import org.bukkit.command.CommandSender;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Locale;
+import java.util.Map;
+
+import static dk.lockfuglsang.minecraft.po.I18nUtil.marktr;
+import static dk.lockfuglsang.minecraft.po.I18nUtil.tr;
+
+public class LanguageCommand extends AbstractCommand {
+    private JavaPlugin plugin;
+
+    public LanguageCommand(JavaPlugin plugin, String name, String permission) {
+        super(name, permission, "language", marktr("changes the language of the plugin, and reloads"));
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean execute(CommandSender sender, String alias, Map<String, Object> data, String... args) {
+        if (args.length == 1) {
+            Locale loc = I18nUtil.getLocale(args[0]);
+            I18nUtil.clearCache();
+            plugin.getConfig().set("language", args[0]);
+            plugin.saveConfig();
+            plugin.reloadConfig();
+            if (I18nUtil.getLocale().equals(I18nUtil.getI18n().getLocale())) {
+                sender.sendMessage(tr("\u00a7aSuccessfully changed language to \u00a7e{0}", loc));
+            } else {
+                sender.sendMessage(tr("\u00a7cFailed to change language to \u00a7e{0}", loc));
+            }
+            return true;
+        } else if (args.length == 0) {
+            try (InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream("gettext-report.txt");
+                 BufferedReader rdr = new BufferedReader(new InputStreamReader(inputStream))) {
+                String line = null;
+                boolean header = true;
+                StringBuilder sb = new StringBuilder();
+                sb.append(tr("\u00a79Supported Languages:\n"));
+                while ((line = rdr.readLine()) != null) {
+                    if (line.startsWith("---")) {
+                        header = false;
+                    } else if (!header && line.contains("|")) {
+                        String parts[] = line.split("\\|");
+                        if (parts.length == 7) {
+                            sb.append(tr("\u00a7f{0} \u00a77{1} \u00a79 by {2} \u00a77{3}\n", parts[1].trim(), parts[0].trim(), parts[6].trim(), parts[2].trim()));
+                        }
+                    }
+                }
+                sender.sendMessage(sb.toString().split("\n"));
+            } catch (IOException e) {
+                sender.sendMessage(tr("\u00a7cUnable to locate any languages."));
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/PlainTextCommandVisitor.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/PlainTextCommandVisitor.java
@@ -1,0 +1,66 @@
+package dk.lockfuglsang.minecraft.command;
+
+import dk.lockfuglsang.minecraft.util.FormatUtil;
+
+import java.io.PrintStream;
+import java.util.List;
+
+import static dk.lockfuglsang.minecraft.po.I18nUtil.tr;
+
+/**
+ * Simple visitor for generating plain-text documentation of an Command-hierarchy.
+ */
+public class PlainTextCommandVisitor extends RowCommandVisitor implements DocumentWriter {
+    private final int linewidth;
+
+    public PlainTextCommandVisitor(int linewidth) {
+        this.linewidth = linewidth;
+    }
+
+    public void writeTo(PrintStream out) {
+        int[] colWidths = new int[3];
+        for (Row row : getRows()) {
+            if (row != null) {
+                if (row.getCommand().length() > colWidths[0]) {
+                    colWidths[0] = row.getCommand().length();
+                }
+                if (row.getPermission().length() > colWidths[1]) {
+                    colWidths[1] = row.getPermission().length();
+                }
+                if (row.getDescription().length() > colWidths[2]) {
+                    colWidths[2] = row.getDescription().length();
+                }
+            }
+        }
+        colWidths[0]++; // make room for the '/'
+        if (colWidths[0] + colWidths[1] + colWidths[2] > linewidth && colWidths[0] + colWidths[1] < linewidth) {
+            // truncate description column
+            colWidths[2] = linewidth - colWidths[0] - colWidths[1];
+        }
+        String rowFormat = "";
+        String separator = "";
+        for (int i = 0; i < colWidths.length; i++) {
+            if (i != 0) {
+                rowFormat += " | ";
+                separator += "-+-";
+            }
+            rowFormat += "%-" + colWidths[i] + "s";
+            separator += String.format("%" + colWidths[i] + "s", "").replaceAll(" ", "-");
+        }
+        out.println(String.format(rowFormat, tr("Command"), tr("Permission"), tr("Description")));
+        for (Row row : getRows()) {
+            if (row == null) {
+                out.println(separator);
+            } else {
+                String cmd = row.getCommand().isEmpty()  ? "" : "/" + row.getCommand();
+                String description = row.getDescription();
+                List<String> strings = FormatUtil.wordWrapStrict(description, colWidths[2]);
+                out.println(String.format(rowFormat, cmd, row.getPermission(), strings.size() > 0 ? strings.get(0) : ""));
+                for (int i = 1; i < strings.size(); i++) {
+                    out.println(String.format(rowFormat, "", "", strings.get(i)));
+                }
+            }
+        }
+    }
+
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/PluginYamlCommandVisitor.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/PluginYamlCommandVisitor.java
@@ -1,0 +1,266 @@
+package dk.lockfuglsang.minecraft.command;
+
+import org.bukkit.command.CommandExecutor;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Generates a yml-file following the syntax define in http://wiki.bukkit.org/Plugin_YAML
+ * @since 1.8
+ */
+public class PluginYamlCommandVisitor implements DocumentWriter {
+    private final int groupDepth;
+
+    List<Command> topLevel = new ArrayList<>();
+    PermissionNode rootNode;
+
+    PluginYamlCommandVisitor() {
+        this(2);
+    }
+
+    PluginYamlCommandVisitor(int groupDepth) {
+        this.groupDepth = groupDepth;
+        rootNode = new PermissionNode("");
+    }
+
+    public void writeTo(PrintStream out) {
+        out.println("commands:");
+        for (Command cmd : topLevel) {
+            out.println("  " + cmd.getName() + ":");
+            out.println("    description: '" + cmd.getDescription().replaceAll("'", "''") + "'");
+            if (cmd.getAliases().length > 1) {
+                String[] copy = new String[cmd.getAliases().length-1];
+                System.arraycopy(cmd.getAliases(), 1, copy, 0, copy.length);
+                out.println("    aliases: " + Arrays.toString(copy));
+            }
+            if (cmd.getPermission() != null && !cmd.getPermission().isEmpty()) {
+                out.println("    permission: " + cmd.getPermission());
+            }
+        }
+        out.println("permissions:");
+        out.println("  #");
+        out.println("  # Permission Groups");
+        out.println("  # =================");
+        for (PermissionNode node : rootNode.getRoots()) {
+            if (!node.permission.isEmpty()) {
+                if (node.permission.split("\\.").length > groupDepth) {
+                    continue; // Skip
+                }
+                out.println("  " + node.permission + ".*:");
+                out.println("    children:");
+                for (String p : node.getChildPermissions()) {
+                    out.println("      " + p + ": true");
+                }
+                out.println();
+            }
+        }
+        out.println("  #");
+        out.println("  # Permission Descriptions");
+        out.println("  # =======================");
+        for (PermissionNode node : rootNode.getLeafs()) {
+            if (!node.permission.isEmpty()) {
+                out.println("  " + node.permission + ":");
+                String desc = node.getDescription();
+                if (desc != null) {
+                    out.println("    description: " + desc);
+                }
+                out.println();
+            }
+        }
+    }
+
+    private static String getCmdDescription(Command cmd) {
+        return "/" + getCommandPath(cmd) + " - " + cmd.getDescription();
+    }
+
+    private static String getCommandPath(Command cmd) {
+        String path = cmd.getParent() != null ? getCommandPath(cmd.getParent()) + " " : "";
+        return path + cmd.getName() + CompositeCommand.getParamsAsString(cmd);
+    }
+
+    @Override
+    public void visit(Command cmd) {
+        if (cmd instanceof CommandExecutor) {
+            topLevel.add(cmd);
+        }
+        String permission = getPermission(cmd);
+        rootNode.add(permission, cmd);
+        for (Map.Entry<String,String> entry : cmd.getFeaturePermissions().entrySet()) {
+            rootNode.add(entry.getKey(), entry.getValue());
+        }
+    }
+
+    private String getPermission(Command cmd) {
+        if (cmd.getPermission() == null && cmd.getParent() != null) {
+            return getPermission(cmd.getParent());
+        } else if (cmd.getPermission() != null) {
+            return cmd.getPermission();
+        }
+        return null;
+    }
+
+    static class PermissionNode implements Comparable<PermissionNode> {
+        String permission;
+        String description; // Used for feature perms
+        List<PermissionNode> children = new ArrayList<>();
+        List<Command> commands = new ArrayList<>();
+
+        PermissionNode(String permission) {
+            this.permission = permission;
+        }
+
+        PermissionNode(String permission, Command cmd) {
+            this.permission = permission;
+            commands.add(cmd);
+        }
+
+        void add(String perm, Command cmd) {
+            if (permission.equalsIgnoreCase(perm) || perm == null) {
+                commands.add(cmd);
+            } else if (perm.startsWith(permission)) {
+                for (PermissionNode child : children) {
+                    if (isSub(child, perm)) {
+                        child.add(perm, cmd);
+                        return;
+                    }
+                }
+                String[] parts = !permission.isEmpty()
+                        ? perm.substring(permission.length() + 1).split("\\.")
+                        : perm.split("\\.");
+                String parentPerm = !permission.isEmpty()
+                        ? permission + "." + parts[0]
+                        : parts[0];
+                PermissionNode n = new PermissionNode(parentPerm);
+                children.add(n);
+                for (int i = 1; i < parts.length; i++) {
+                    parentPerm += "." + parts[i];
+                    PermissionNode newNode = new PermissionNode(parentPerm);
+                    n.children.add(newNode);
+                    n = newNode;
+                }
+                n.commands.add(cmd);
+            }
+        }
+
+        private boolean isSub(PermissionNode child, String perm) {
+            return perm.startsWith(child.permission)
+                    && (child.permission.equalsIgnoreCase(perm) || (perm.length() > child.permission.length()
+                    && perm.charAt(child.permission.length()) == '.')
+                    );
+        }
+
+        void add(String perm, String description) {
+            if (permission.equalsIgnoreCase(perm) || perm == null) {
+                if (this.description == null) {
+                    this.description = description;
+                }
+            } else if (perm.startsWith(permission)) {
+                for (PermissionNode child : children) {
+                    if (isSub(child, perm)) {
+                        child.add(perm, description);
+                        return;
+                    }
+                }
+                String[] parts = !permission.isEmpty()
+                        ? perm.substring(permission.length() + 1).split("\\.")
+                        : perm.split("\\.");
+                String parentPerm = !permission.isEmpty()
+                        ? permission + "." + parts[0]
+                        : parts[0];
+                PermissionNode n = new PermissionNode(parentPerm);
+                children.add(n);
+                for (int i = 1; i < parts.length; i++) {
+                    parentPerm += "." + parts[i];
+                    PermissionNode newNode = new PermissionNode(parentPerm);
+                    n.children.add(newNode);
+                    n = newNode;
+                }
+                n.description = description;
+            }
+        }
+
+        List<String> getChildPermissions() {
+            List<String> perms = new ArrayList<>();
+            for (PermissionNode child : children) {
+                perms.add(child.permission);
+                perms.addAll(child.getChildPermissions());
+            }
+            Collections.sort(perms);
+            return perms;
+        }
+
+        void addRoots(List<PermissionNode> roots) {
+            if (!children.isEmpty()) {
+                roots.add(this);
+                for (PermissionNode node : children) {
+                    node.addRoots(roots);
+                }
+            }
+        }
+
+        List<PermissionNode> getRoots() {
+            List<PermissionNode> roots = new ArrayList<>();
+            addRoots(roots);
+            Collections.sort(roots);
+            return roots;
+        }
+
+        void addLeafs(List<PermissionNode> leafs) {
+            if (children.isEmpty() || !commands.isEmpty()) {
+                leafs.add(this);
+            }
+            for (PermissionNode node : children) {
+                node.addLeafs(leafs);
+            }
+        }
+
+        List<PermissionNode> getLeafs() {
+            List<PermissionNode> leafs = new ArrayList<>();
+            addLeafs(leafs);
+            Collections.sort(leafs);
+            return leafs;
+        }
+
+        String getDescription() {
+            if (description != null) {
+                return "'" + description + "'";
+            }
+            if (commands.size() == 1) {
+                return "'Grants access to " + getCmdDescription(commands.get(0)) + "'";
+            } else if (commands.size() > 1) {
+                String desc = "|" + System.lineSeparator();
+                desc += "      Grants access to " + getCmdDescription(commands.get(0));
+                for (int i = 1; i < commands.size(); i++) {
+                    desc += System.lineSeparator();
+                    desc += "      " + getCmdDescription(commands.get(i));
+                }
+                return desc;
+            }
+            return null;
+        }
+
+        public PermissionNode find(String perm) {
+            if (permission.equals(perm)) {
+                return this;
+            } else if (perm.startsWith(permission)) {
+                for (PermissionNode n : children) {
+                    PermissionNode r = n.find(perm);
+                    if (r != null) {
+                        return r;
+                    }
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public int compareTo(PermissionNode o) {
+            return permission.compareTo(o.permission);
+        }
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/README.md
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/README.md
@@ -1,0 +1,73 @@
+# Commands
+
+This package contains a lot of convenience classes to easily create commands for use with Bukkit.
+
+It has an in-build help system, with pagination, and permission-control.
+
+# Usage
+
+## Getting Started
+
+To create a composite entry-level command, simply inherit from the `AbstractCommandExecutor` in your main plugin.
+
+```java
+class MyPlugin extends JavaPlugin {
+    @Override
+    public void onEnable() {
+        mycmd = new AbstractCommandExecutor("mycmd", "myplugin.perm.mycmd", "main myplugin command");
+        mycmd.add(new AbstractCommand("hello|h", "myplugin.perm.hello", "say hello to the player") {
+            @Override
+            public boolean execute(CommandSender sender, String alias, Map<String, Object> data, String... args) {
+                sender.sendMessage(new String[]{
+                        "Hello! and welcome " + sender.getName(),
+                        "I was called with : " + alias,
+                        "I had " + args.length + " arguments: " + Arrays.asList(args)
+                });
+                return true;
+            }
+        });
+        getCommand("mycmd", mycmd);
+    }
+}
+```
+
+The above code, will register 2 commands for the plugin.
+One is nested within the other.
+
+Help is automatically generated, so invoking `/mycmd` will show a list of possible options.
+Invoking `/mycmd h your momma` will output:
+
+```
+Hello! and welcome CONSOLE
+I was called with : h
+I had 2 arguments: [your, momma]
+```
+
+## Tab-Completion
+
+All CompositeCommands have automatic tab-completion of their sub-commands.
+
+If you want to have tab-completion of arguments, you can easily roll your own:
+
+```java
+monsterTab = new AbstractTabCompleter() {
+  @Override
+  protected List<String> getTabList(CommandSender commandSender, String term) {
+    return Arrays.asList("animal", "monster", "villager");
+  }
+}
+```
+The above tab-completer will do filtering automatically.
+
+Tab-completers can be re-used, if they handle a named argument:
+
+```java
+  public class MyCmd extends CompositeCommand {
+    public MyCmd() {
+      super("mycmd", "perm.mycmd", "main command");
+      add(new AbstractCommand("list", "perm.list", "?monster", "lists a subset") { ... });
+      add(new AbstractCommand("spawn", "perm.spawn", "monster", "spawn a monster") { ... });
+      addTab("monster", monsterTab);
+    }
+  }
+```

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/RowCommandVisitor.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/RowCommandVisitor.java
@@ -1,0 +1,90 @@
+package dk.lockfuglsang.minecraft.command;
+
+import org.bukkit.command.CommandExecutor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static dk.lockfuglsang.minecraft.po.I18nUtil.tr;
+
+/**
+ * A visitor that simply gathers the complete command-hierarchy into a list of rows.
+ * @since 1.8
+ */
+class RowCommandVisitor implements CommandVisitor {
+    private final List<Row> rows = new ArrayList<>();
+
+    public List<Row> getRows() {
+        return rows;
+    }
+
+    @Override
+    public void visit(Command cmd) {
+        if (cmd instanceof CommandExecutor) {
+            rows.add(null); // separator
+        }
+        String commandPath = getCommandPath(cmd);
+        String alias = getAliases(cmd);
+        if (!alias.isEmpty()) {
+            String shortCmd = getShortestCmd(cmd);
+            int ix = commandPath.lastIndexOf(" " + shortCmd) + 1;
+            commandPath = commandPath.substring(0, ix) + cmd.getName() + alias + commandPath.substring(ix+shortCmd.length());
+        }
+        rows.add(new Row(commandPath, cmd.getDescription(), cmd.getPermission()));
+        List<String> extraPerms = new ArrayList<>(cmd.getFeaturePermissions().keySet());
+        Collections.sort(extraPerms);
+        for (String p : extraPerms) {
+            rows.add(new Row(null, cmd.getFeaturePermissions().get(p), p));
+        }
+    }
+
+    private String getCommandPath(Command cmd) {
+        String path = cmd.getParent() != null ? getCommandPath(cmd.getParent()) + " " : "";
+        return path + getShortestCmd(cmd) + CompositeCommand.getParamsAsString(cmd);
+    }
+
+    private String getShortestCmd(Command cmd) {
+        String cmdName = cmd.getName();
+        for (String alias : cmd.getAliases()) {
+            if (alias.length() < cmdName.length()) {
+                cmdName = alias;
+            }
+        }
+        return cmdName;
+    }
+
+    private String getAliases(Command cmd) {
+        String aliases = "";
+        for (int i = 1; i < cmd.getAliases().length; i++) {
+            aliases += "|" + cmd.getAliases()[i];
+        }
+        return aliases;
+    }
+
+    static class Row {
+        private final String command;
+        private final String description;
+        private final String permission;
+
+        Row(String command, String description, String permission) {
+            this.command = command;
+            this.description = description;
+            this.permission = permission;
+        }
+
+        public String getCommand() {
+            return command != null ? command : "";
+        }
+
+        public String getDescription() {
+            return description != null ? description : "";
+        }
+
+        public String getPermission() {
+            return permission != null ? permission : "";
+        }
+
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/completion/AbstractTabCompleter.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/completion/AbstractTabCompleter.java
@@ -1,0 +1,43 @@
+package dk.lockfuglsang.minecraft.command.completion;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Common ancestor of the TabCompleters.
+ * Uses the Template Pattern for sub-classes.
+ */
+public abstract class AbstractTabCompleter implements TabCompleter {
+
+    abstract protected List<String> getTabList(CommandSender commandSender, String term);
+
+    @Override
+    public List<String> onTabComplete(CommandSender commandSender, Command command, String alias, String[] args) {
+        String term = args.length > 0 ? args[args.length-1] : "";
+        return filter(getTabList(commandSender, term), term);
+    }
+
+    public static List<String> filter(List<String> list, String prefix) {
+        Set<String> filtered = new LinkedHashSet<>();
+        if (list != null) {
+            Collections.sort(list);
+            String lowerPrefix = prefix.toLowerCase();
+            for (String test : list) {
+                if (test.toLowerCase().startsWith(lowerPrefix)) {
+                    filtered.add(test);
+                }
+            }
+        }
+        if (filtered.size() > 20) {
+            return new ArrayList<>(filtered).subList(0, 20);
+        }
+        return new ArrayList<>(filtered);
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/completion/CompositeTabCompleter.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/completion/CompositeTabCompleter.java
@@ -1,0 +1,26 @@
+package dk.lockfuglsang.minecraft.command.completion;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+
+import java.util.List;
+
+/**
+ * TabCompleter that supports multiple tab-completers for different arguments.
+ */
+public class CompositeTabCompleter implements TabCompleter {
+    private final TabCompleter[] completers;
+
+    public CompositeTabCompleter(TabCompleter... completers) {
+        this.completers = completers;
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender commandSender, Command command, String alias, String[] args) {
+        if (completers.length <= args.length) {
+            return completers[args.length-1].onTabComplete(commandSender, command, alias, args);
+        }
+        return null;
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/completion/OfflinePlayerTabCompleter.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/completion/OfflinePlayerTabCompleter.java
@@ -1,0 +1,24 @@
+package dk.lockfuglsang.minecraft.command.completion;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.CommandSender;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Convenience implementation of a tab-completer for all offline players
+ */
+public class OfflinePlayerTabCompleter extends AbstractTabCompleter {
+    @Override
+    protected List<String> getTabList(CommandSender commandSender, String term) {
+        List<String> tabList = new ArrayList<>();
+        for (OfflinePlayer player : Bukkit.getOfflinePlayers()) {
+            if (player != null) {
+                tabList.add(player.getName());
+            }
+        }
+        return tabList;
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/completion/OnlinePlayerTabCompleter.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/command/completion/OnlinePlayerTabCompleter.java
@@ -1,0 +1,24 @@
+package dk.lockfuglsang.minecraft.command.completion;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Convenience implementation of a tab-completer for all online players
+ */
+public class OnlinePlayerTabCompleter extends AbstractTabCompleter {
+    @Override
+    protected List<String> getTabList(CommandSender commandSender, String term) {
+        List<String> tabList = new ArrayList<>();
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (player != null && player.isOnline()) {
+                tabList.add(player.getName());
+            }
+        }
+        return tabList;
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/file/FileUtil.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/file/FileUtil.java
@@ -1,0 +1,334 @@
+package dk.lockfuglsang.minecraft.file;
+
+import dk.lockfuglsang.minecraft.yml.YmlConfiguration;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Common file-utilities.
+ */
+public enum FileUtil {;
+    private static final Logger log = Logger.getLogger(FileUtil.class.getName());
+    private static final Collection<String> allwaysOverwrite = new ArrayList<>();
+    private static final Collection<String> neverOverwrite = new ArrayList<>();
+    private static final Map<String, YmlConfiguration> configFiles = new ConcurrentHashMap<>();
+    private static Locale locale = Locale.getDefault();
+    private static File dataFolder;
+
+    public static void setAllwaysOverwrite(String... configs) {
+        for (String s : configs) {
+            if (!allwaysOverwrite.contains(s)) {
+                allwaysOverwrite.add(s);
+            }
+        }
+    }
+
+    public static void setNeverOverwrite(String... configs) {
+        for (String s : configs) {
+            if (!neverOverwrite.contains(s)) {
+                neverOverwrite.add(s);
+            }
+        }
+    }
+
+    public static YmlConfiguration loadConfig(File file) {
+        YmlConfiguration config = new YmlConfiguration();
+        readConfig(config, file);
+        return config;
+    }
+
+    public static void readConfig(FileConfiguration config, File file) {
+        if (file == null) {
+            log.log(Level.INFO, "No "  + file + " found, it will be created");
+            return;
+        }
+        File configFile = file;
+        File localeFile = new File(configFile.getParentFile(), getLocaleName(file.getName()));
+        if (localeFile.exists() && localeFile.canRead()) {
+            configFile = localeFile;
+        }
+        if (!configFile.exists()) {
+            log.log(Level.INFO, "No "  + configFile + " found, it will be created");
+            return;
+        }
+        try (Reader rdr = new InputStreamReader(new FileInputStream(configFile), "UTF-8")) {
+            config.load(rdr);
+        } catch (InvalidConfigurationException e) {
+            log.log(Level.SEVERE, "Unable to read config file " + configFile, e);
+            if (configFile.exists()) {
+                try {
+                    Files.copy(Paths.get(configFile.toURI()), Paths.get(configFile.getParent(), configFile.getName() + ".err"), StandardCopyOption.REPLACE_EXISTING);
+                } catch (IOException e1) {
+                    // Ignore - we tried...
+                }
+            }
+        } catch (IOException e) {
+            log.log(Level.SEVERE, "Unable to read config file " + configFile, e);
+        }
+    }
+
+    public static void readConfig(FileConfiguration config, InputStream inputStream) {
+        if (inputStream == null) {
+            return;
+        }
+        try (Reader rdr = new InputStreamReader(inputStream, "UTF-8")) {
+            config.load(rdr);
+        } catch (InvalidConfigurationException | IOException e) {
+            log.log(Level.SEVERE, "Unable to read configuration", e);
+        }
+    }
+
+    public static FilenameFilter createYmlFilenameFilter() {
+        return new FilenameFilter() {
+            @Override
+            public boolean accept(File dir, String name) {
+                return name != null && name.endsWith(".yml");
+            }
+        };
+    }
+
+    public static String getBasename(File file) {
+        return getBasename(file.getName());
+    }
+
+    public static String getBasename(String file) {
+        String[] lastPart = file.split("(/|\\\\)");
+        file = lastPart[lastPart.length-1];
+        if (file != null && file.lastIndexOf('.') != -1) {
+            return file.substring(0, file.lastIndexOf('.'));
+        }
+        return file;
+    }
+
+    public static String getExtension(String fileName) {
+        if (fileName != null && !fileName.isEmpty()) {
+            return fileName.substring(getBasename(fileName).length()+1);
+        }
+        return "";
+    }
+
+    private static File getDataFolder() {
+        return dataFolder != null ? dataFolder : new File(".");
+    }
+
+    /**
+     * System-encoding agnostic config-reader
+     * Reads and returns the configuration found in:
+     * <pre>
+     *   a) the datafolder
+     *
+     *     a.1) if a config named "config_en.yml" exists - that is read.
+     *
+     *     a.2) otherwise "config.yml" is read (created if need be).
+     *
+     *   b) if the version differs from the same resource on the classpath
+     *
+     *      b.1) all nodes in the jar-file-version is merged* into the local-file
+     *
+     *      b.2) unless the configName is in the allwaysOverwrite - then the jar-version wins
+     *
+     * *merged: using data-conversion of special nodes.
+     * </pre>
+     */
+    public static YmlConfiguration getYmlConfiguration(String configName) {
+        // Caching, for your convenience! (and a bigger memory print!)
+
+        if (!configFiles.containsKey(configName)) {
+            YmlConfiguration config = new YmlConfiguration();
+            try {
+                // read from datafolder!
+                File configFile = getConfigFile(configName);
+                YmlConfiguration configJar = new YmlConfiguration();
+                readConfig(config, configFile);
+                readConfig(configJar, getResource(configName));
+                if (!configFile.exists() || config.getInt("version", 0) < configJar.getInt("version", 0)) {
+                    if (configFile.exists()) {
+                        if (neverOverwrite.contains(configName)) {
+                            configFiles.put(configName, config);
+                            return config;
+                        }
+                        File backupFolder = new File(getDataFolder(), "backup");
+                        backupFolder.mkdirs();
+                        String bakFile = String.format("%1$s-%2$tY%2$tm%2$td-%2$tH%2$tM.yml", getBasename(configName), new Date());
+                        log.log(Level.INFO, "Moving existing config " + configName + " to backup/" + bakFile);
+                        Files.move(Paths.get(configFile.toURI()),
+                                Paths.get(new File(backupFolder, bakFile).toURI()),
+                                StandardCopyOption.REPLACE_EXISTING);
+                        if (allwaysOverwrite.contains(configName)) {
+                            FileUtil.copy(getResource(configName), configFile);
+                            config = configJar;
+                        } else {
+                            config = mergeConfig(configJar, config);
+                            config.save(configFile);
+                            config.load(configFile);
+                        }
+                    } else {
+                        config = mergeConfig(configJar, config);
+                        config.save(configFile);
+                        config.load(configFile);
+                    }
+                }
+            } catch (Exception e) {
+                log.log(Level.SEVERE, "Unable to handle config-file " + configName, e);
+            }
+            configFiles.put(configName, config);
+        }
+        return configFiles.get(configName);
+    }
+
+    private static InputStream getResource(String configName) {
+        String resourceName = getLocaleName(configName);
+        ClassLoader loader = FileUtil.class.getClassLoader();
+        InputStream resourceAsStream = loader.getResourceAsStream(resourceName);
+        if (resourceAsStream != null) {
+            return resourceAsStream;
+        }
+        return loader.getResourceAsStream(configName);
+    }
+
+    private static String getLocaleName(String fileName) {
+        String baseName = getBasename(fileName);
+        return baseName + "_" + locale + fileName.substring(baseName.length());
+    }
+
+    public static File getConfigFile(String configName) {
+        File file = new File(getDataFolder(), getLocaleName(configName));
+        if (file.exists()) {
+            return file;
+        }
+        return new File(getDataFolder(), configName);
+    }
+
+    public static void copy(InputStream stream, File file) throws IOException {
+        if (stream == null || file == null) {
+            throw new IOException("Invalid resource for " + file);
+        }
+        Files.copy(stream, Paths.get(file.toURI()), StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    /**
+     * Merges the important keys from src to destination.
+     * @param src The source (containing the new values).
+     * @param dest The destination (containing old-values).
+     */
+    private static YmlConfiguration mergeConfig(YmlConfiguration src, YmlConfiguration dest) {
+        int existing = dest.getInt("version");
+        int version = src.getInt("version", existing);
+        dest.setDefaults(src);
+        dest.options().copyDefaults(true);
+        dest.addComments(src.getComments());
+        dest.set("version", version);
+        dest.options().copyHeader(false);
+        src.options().copyHeader(false);
+        removeExcludes(dest);
+        moveNodes(src, dest);
+        replaceDefaults(src, dest);
+        return dest;
+    }
+
+    /**
+     * Removes nodes from dest.defaults, that are specifically excluded in the config
+     */
+    private static void removeExcludes(YmlConfiguration dest) {
+        List<String> keys = dest.getStringList("merge-ignore");
+        for (String key : keys) {
+            dest.getDefaults().set(key, null);
+        }
+    }
+
+    private static void replaceDefaults(YmlConfiguration src, YmlConfiguration dest) {
+        ConfigurationSection forceSection = src.getConfigurationSection("force-replace");
+        if (forceSection != null) {
+            for (String key : forceSection.getKeys(true)) {
+                Object def = forceSection.get(key, null);
+                Object value = dest.get(key, def);
+                Object newDef = src.get(key, null);
+                if (def != null && def.equals(value)) {
+                    dest.set(key, newDef);
+                }
+            }
+        }
+        dest.set("force-replace", null);
+        dest.getDefaults().set("force-replace", null);
+    }
+
+    private static void moveNodes(YmlConfiguration src, YmlConfiguration dest) {
+        ConfigurationSection moveSection = src.getConfigurationSection("move-nodes");
+        if (moveSection != null) {
+            List<String> keys = new ArrayList<>(moveSection.getKeys(true));
+            Collections.reverse(keys); // Depth first
+            for (String key : keys) {
+                if (moveSection.isString(key)) {
+                    String srcPath = key;
+                    String tgtPath = moveSection.getString(key, key);
+                    Object value = dest.get(srcPath);
+                    if (value != null) {
+                        dest.set(tgtPath, value);
+                        dest.set(srcPath, null);
+                    }
+                } else if (moveSection.isConfigurationSection(key)) {
+                    // Check to see if dest section should be nuked...
+                    if (dest.isConfigurationSection(key) && dest.getConfigurationSection(key).getKeys(false).isEmpty()) {
+                        dest.set(key, null);
+                    }
+                }
+            }
+        }
+        dest.set("move-nodes", null);
+        dest.getDefaults().set("move-nodes", null);
+    }
+
+    public static void setDataFolder(File dataFolder) {
+        FileUtil.dataFolder = dataFolder;
+        configFiles.clear();
+    }
+
+    public static void setLocale(Locale loc) {
+        locale = loc != null ? loc : locale;
+    }
+
+    public static void reload() {
+        for (Map.Entry<String, YmlConfiguration> e : configFiles.entrySet()) {
+            File configFile = new File(getDataFolder(), e.getKey());
+            readConfig(e.getValue(), configFile);
+        }
+    }
+
+    public static Properties readProperties(String fileName) {
+        File configFile = getConfigFile(fileName);
+        if (configFile != null && configFile.exists() && configFile.canRead()) {
+            Properties prop = new Properties();
+            try (InputStreamReader in = new InputStreamReader(new FileInputStream(configFile), "UTF-8")) {
+                prop.load(in);
+                return prop;
+            } catch (IOException e) {
+                log.log(Level.WARNING, "Error reading " + fileName, e);
+            }
+        }
+        return null;
+    }
+
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/file/README.md
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/file/README.md
@@ -1,0 +1,47 @@
+# File Utilities
+
+The `FileUtil` class simplifies resource reading for Bukkit plugins.
+
+## Features
+
+The primary usage of the FileUtil, is to read yml-files from the plugin-datafolder.
+
+The utility supports the following features:
+
+  * Reading files in UTF-8, regardless of system-encoding.
+  * Support merging yml files from classpath (jar) with plugin files.
+  * Support for `version`ing of individual yml files.
+  * Support for localization of configuration files.
+  * Support for data-conversion on merges.
+  * Support caching of configuration objects (only read from disk once).
+
+## Usage
+
+```java
+  @Override
+  void onEnable() {
+    FileUtil.setDataFolder(getDataFolder()); // init plugin-data-folder
+    FileUtil.setLocale(new Locale("en"));    // set locale used in locating translated resources
+
+    YmlConfiguration config = FileUtil.getYmlConfiguration("config.yml");
+    if (config.getBoolean("feature.enabled", true)) {
+      // do feature stuff
+    }
+  }
+```
+
+The `config` in the above example is created the following way:
+  * Read `config.yml` from the data-folder
+    * if a `config_en.yml` exists - read it
+    * else if a `config.yml` exist - read it
+  * Read `config.yml` from the jar-file (classpath)
+    * if a 'config_en.yml` exists - read it
+    * else if a `config.yml` exsits - read it
+  * Compare `version` read from both configs
+    * if `config.yml` is listed in `allwaysOverwrite` - just use the jar-file
+    * else if jar-version > file-version or file-version does not exist
+      * merge nodes from jar into config - preserving node-comments
+        * ignore nodes listed in `merge-ignore` from the existing config-file
+        * move nodes listed in `move-nodes` from the jar-file
+        * replace nodes listed in `replace-nodes` from the jar-file, if they have default values
+        * set `version` to the jar-file version

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/gui/package-info.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/gui/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Holds a frame-work for making GUI components (inventory based) in Bukkit Minecraft.
+ */
+package dk.lockfuglsang.minecraft.gui;

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/nbt/CraftBukkitNBTTagger.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/nbt/CraftBukkitNBTTagger.java
@@ -1,0 +1,100 @@
+package dk.lockfuglsang.minecraft.nbt;
+
+import org.bukkit.inventory.ItemStack;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import static dk.lockfuglsang.minecraft.reflection.ReflectionUtil.*;
+
+/**
+ * An NBTItemStackTagger using reflection for CraftBukkit based servers.
+ */
+public class CraftBukkitNBTTagger implements NBTItemStackTagger {
+    private static final Logger log = Logger.getLogger(CraftBukkitNBTTagger.class.getName());
+
+    @Override
+    public String getNBTTag(ItemStack itemStack) {
+        if (itemStack == null) {
+            return "";
+        }
+        Object nmsItem = execStatic(getCraftItemStackClass(), "asNMSCopy", itemStack);
+        Object nbtTag = exec(nmsItem, "getTag");
+        return nbtTag != null ? "" + nbtTag : "";
+    }
+
+    @Override
+    public ItemStack setNBTTag(ItemStack itemStack, String nbtTagString) {
+        if (itemStack == null || nbtTagString == null || nbtTagString.isEmpty()) {
+            return itemStack;
+        }
+        Object nmsItem = execStatic(getCraftItemStackClass(), "asNMSCopy", itemStack);
+        Object nbtTag = execStatic(getNBTTagParser(), "parse", nbtTagString);
+        exec(nmsItem, "setTag", nbtTag);
+        Object item = execStatic(getCraftItemStackClass(), "asBukkitCopy", nmsItem);
+        if (item instanceof ItemStack) {
+            return (ItemStack) item;
+        }
+        return itemStack;
+    }
+
+    @Override
+    public ItemStack addNBTTag(ItemStack itemStack, String nbtTagString) {
+        if (itemStack == null || nbtTagString == null || nbtTagString.isEmpty()) {
+            return itemStack;
+        }
+        Object nmsItem = execStatic(getCraftItemStackClass(), "asNMSCopy", itemStack);
+        Object nbtTag = exec(nmsItem, "getTag");
+        Object nbtTagNew = execStatic(getNBTTagParser(), "parse", nbtTagString);
+        nbtTag = merge(nbtTagNew, nbtTag);
+        exec(nmsItem, "setTag", nbtTag);
+        Object item = execStatic(getCraftItemStackClass(), "asBukkitCopy", nmsItem);
+        if (item instanceof ItemStack) {
+            return (ItemStack) item;
+        }
+        return itemStack;
+    }
+
+    /**
+     * Merges two NBTTagCompound objects
+     */
+    private static Object merge(Object src, Object tgt) {
+        if (tgt == null) {
+            return src;
+        }
+        try {
+            Field mapField = src.getClass().getDeclaredField("x");
+            mapField.setAccessible(true);
+            Map<String, Object> map = (Map<String, Object>) mapField.get(src);
+            Class<?> NBTBase = Class.forName(getPackageName(tgt) + ".NBTBase");
+            for (String key : map.keySet()) {
+                Object val = exec(src, "get", new Class[]{String.class}, key);
+                exec(tgt, "set", new Class[]{String.class, NBTBase}, key, val);
+            }
+            return tgt;
+        } catch (IllegalAccessException | ClassNotFoundException | NoSuchFieldException e) {
+            log.info("Unable to transfer NBTTag from " + src + " to " + tgt + ": " + e);
+        }
+        return tgt;
+    }
+
+    private static Class<?> getNBTTagParser() {
+        try {
+            return Class.forName("net.minecraft.nbt.MojangsonParser");
+        } catch (ClassNotFoundException e) {
+            log.info("Unable to instantiate MojangsonParser: " + e);
+        }
+        return null;
+    }
+
+    private static Class<?> getCraftItemStackClass() {
+        String version = getCraftBukkitVersion();
+        try {
+            return Class.forName("org.bukkit.craftbukkit." + version + ".inventory.CraftItemStack");
+        } catch (Exception e) {
+            log.info("Unable to find CraftItemStack: " + e);
+        }
+        return null;
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/nbt/NBTItemStackTagger.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/nbt/NBTItemStackTagger.java
@@ -1,0 +1,33 @@
+package dk.lockfuglsang.minecraft.nbt;
+
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Interface for allowing depencency injection for testing (and other platforms than CraftBukkit).
+ */
+public interface NBTItemStackTagger {
+    /**
+     * Returns the NBTTag of the <code>itemStack</code> as a string, or the empty-string if none was found.
+     * @param itemStack A Bukkit ItemStack
+     * @return the NBTTag
+     * @since 1.7.2
+     */
+    String getNBTTag(ItemStack itemStack);
+    /**
+     * Returns a copy of the <code>itemStack</code> with the supplied <code>nbtTagString</code> applied.
+     * @param itemStack     A Bukkit ItemStack
+     * @param tag  A valid NBTTag string
+     * @return a copy of the <code>itemStack</code>
+     * @since 1.7.2
+     */
+    ItemStack setNBTTag(ItemStack itemStack, String tag);
+
+    /**
+     * Returns a copy of the <code>itemStack</code> with the supplied <code>nbtTagString</code> applied.
+     * @param itemStack     A Bukkit ItemStack
+     * @param tag  A valid NBTTag string
+     * @return a copy of the <code>itemStack</code>
+     * @since 1.7.2
+     */
+    ItemStack addNBTTag(ItemStack itemStack, String tag);
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/nbt/NBTUtil.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/nbt/NBTUtil.java
@@ -1,0 +1,63 @@
+package dk.lockfuglsang.minecraft.nbt;
+
+import org.bukkit.inventory.ItemStack;
+
+import java.util.logging.Logger;
+
+/**
+ * Utility for setting NBTTag data on Bukkit items without NMS (using reflection).
+ * @since 1.7
+ */
+public enum NBTUtil { ;
+    private static final Logger log = Logger.getLogger(NBTUtil.class.getName());
+
+    private static NBTItemStackTagger tagger = new CraftBukkitNBTTagger();
+
+    /**
+     * Returns the NBTTag of the <code>itemStack</code> as a string, or the empty-string if none was found.
+     * @param itemStack A Bukkit ItemStack
+     * @return the NBTTag
+     * @since 1.7
+     */
+    public static String getNBTTag(ItemStack itemStack) {
+        if (itemStack == null) {
+            return "";
+        }
+        return tagger.getNBTTag(itemStack);
+    }
+
+    /**
+     * Returns a copy of the <code>itemStack</code> with the supplied <code>nbtTagString</code> applied.
+     * @param itemStack     A Bukkit ItemStack
+     * @param nbtTagString  A valid NBTTag string
+     * @return a copy of the <code>itemStack</code>
+     * @since 1.7
+     */
+    public static ItemStack setNBTTag(ItemStack itemStack, String nbtTagString) {
+        if (itemStack == null || nbtTagString == null || nbtTagString.isEmpty()) {
+            return itemStack;
+        }
+        return tagger.setNBTTag(itemStack, nbtTagString);
+    }
+
+    /**
+     * Returns a copy of the <code>itemStack</code> with the supplied <code>nbtTagString</code> applied.
+     * @param itemStack     A Bukkit ItemStack
+     * @param nbtTagString  A valid NBTTag string
+     * @return a copy of the <code>itemStack</code>
+     * @since 1.7
+     */
+    public static ItemStack addNBTTag(ItemStack itemStack, String nbtTagString) {
+        if (itemStack == null || nbtTagString == null || nbtTagString.isEmpty()) {
+            return itemStack;
+        }
+        return tagger.addNBTTag(itemStack, nbtTagString);
+    }
+
+    public static void setNBTItemStackTagger(NBTItemStackTagger tagger) {
+        if (tagger == null) {
+            throw new IllegalArgumentException("tagger cannot be null");
+        }
+        NBTUtil.tagger = tagger;
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/nbt/README.md
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/nbt/README.md
@@ -1,0 +1,5 @@
+# NBT Utilities
+
+This package contains utilities to access/tweak the NBTTags when running a Bukkit plugin.
+
+# License

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/reflection/ReflectionUtil.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/reflection/ReflectionUtil.java
@@ -1,0 +1,356 @@
+package dk.lockfuglsang.minecraft.reflection;
+
+import org.bukkit.Bukkit;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+/**
+ * Wrapper methods that allow accesss to reflection for backward compatible code.
+ *
+ * @since 1.8
+ */
+public class ReflectionUtil {
+    private static final Logger log = Logger.getLogger(ReflectionUtil.class.getName());
+
+    /**
+     * Returns the current version of the Bukkit implementation
+     *
+     * @return the current version of the Bukkit implementation
+     * @since 1.8
+     */
+    public static String getCraftBukkitVersion() {
+        return cb().split("\\.")[3];
+    }
+
+    /**
+     * Returns the current version of the net.minecraft.server implementation
+     *
+     * @param nmsObject A native object from nms namespace
+     * @return the current version of the net.minecraft.server implementation
+     * @since 1.8
+     */
+    public static String getNMSVersion(Object nmsObject) {
+        return nmsObject != null ? nmsObject.getClass().getPackage().getName().split("\\.")[3] : "";
+    }
+
+    /**
+     * Returns the NMS version.
+     * @return the NMS version (i.e. "v1_10").
+     * @since 1.9
+     */
+    public static String getNMSVersion() {
+        return nms().split("\\.")[3];
+    }
+
+    /**
+     * Returns the real packagename for the net.minecraft.server.
+     * @return the real packagename for the net.minecraft.server.
+     * @since 1.9
+     */
+    public static String nms() {
+        Object nmsServer = exec(Bukkit.getServer(), "getServer");
+        return nmsServer != null ? nmsServer.getClass().getPackage().getName() : "net.minecraft.server";
+    }
+
+    /**
+     * Returns the real packagename for the org.bukkit.craftbukkit package
+     * @return the real packagename for the org.bukkit.craftbukkit package
+     * @since 1.9
+     */
+    public static String cb() {
+        return Bukkit.getServer().getClass().getPackage().getName();
+    }
+
+    /**
+     * Returns the packagename of the given object.
+     *
+     * @param nmsObject An object
+     * @return the packagename of the given object.
+     * @since 1.8
+     */
+    public static String getPackageName(Object nmsObject) {
+        return nmsObject != null ? nmsObject.getClass().getPackage().getName() : "";
+    }
+
+    /**
+     * Returns the corresponding Bukkit class, given a CraftBukkit implementation object.
+     *
+     * @param craftObject A CraftBukkit implementation of a Bukkit class.
+     * @return the corresponding Bukkit class, given a CraftBukkit implementation object.
+     * @since 1.8
+     */
+    public static Class<?> getBukkitClass(Object craftObject) {
+        Class clazz = craftObject != null ? craftObject.getClass() : null;
+        while (clazz != null && clazz.getCanonicalName().contains(".craftbukkit.")) {
+            clazz = clazz.getSuperclass();
+        }
+        return clazz;
+    }
+
+    /**
+     * Uses reflection to execute the named method on the supplied class giving the arguments.
+     * Sinks all exceptions, but log an entry and returns <code>null</code>
+     *
+     * @param clazz      The class on which to invoke the method
+     * @param methodName The name of the method to invoke
+     * @param args       The arguments to supply to the method
+     * @return <code>null</code> or the return-object from the method.
+     * @since 1.8
+     */
+    public static <T> T execStatic(Class<?> clazz, String methodName, Object... args) {
+        try {
+            Class[] argTypes = new Class[args.length];
+            int ix = 0;
+            for (Object arg : args) {
+                argTypes[ix++] = getBukkitClass(arg);
+            }
+            Method method = getMethod(clazz, methodName, argTypes);
+            boolean wasAccessible = method.isAccessible();
+            method.setAccessible(true);
+            try {
+                return (T) method.invoke(null, args);
+            } finally {
+                method.setAccessible(wasAccessible);
+            }
+        } catch (NoSuchMethodException e) {
+            log.fine("Unable to locate method " + methodName + " on " + clazz);
+        } catch (InvocationTargetException | IllegalAccessException e) {
+            log.log(Level.INFO, "Calling " + methodName + " on " + clazz + " threw an exception", e);
+        }
+        return null;
+    }
+
+    /**
+     * Uses reflection to execute the named method on the supplied class giving the arguments.
+     * Sinks all exceptions, but log an entry and returns <code>null</code>
+     *
+     * @param obj        The object on which to invoke the method
+     * @param methodName The name of the method to invoke
+     * @param argTypes   An array of argument-types (classes).
+     * @param args       The arguments to supply to the method
+     * @return <code>null</code> or the return-object from the method.
+     * @since 1.8
+     */
+    public static <T> T exec(Object obj, String methodName, Class[] argTypes, Object... args) {
+        if (obj == null) {
+            return null;
+        }
+        Class<?> aClass = obj.getClass();
+        try {
+            Method method = getMethod(aClass, methodName, argTypes);
+            boolean wasAccessible = method.isAccessible();
+            method.setAccessible(true);
+            try {
+                return (T) method.invoke(obj, args);
+            } finally {
+                method.setAccessible(wasAccessible);
+            }
+        } catch (NoSuchMethodException | AbstractMethodError e) {
+            log.fine("Unable to locate method " + methodName + "(" + Arrays.asList(argTypes) + ") on " + aClass);
+        } catch (InvocationTargetException | IllegalAccessException e) {
+            log.log(Level.INFO, "Calling " + methodName + " on " + obj + " threw an exception", e);
+        }
+        return null;
+    }
+
+    public static Method getMethod(Class<?> aClass, String methodName, Class... argTypes) throws NoSuchMethodException {
+        try {
+            // Declared gives access to non-public
+            return aClass.getDeclaredMethod(methodName, argTypes);
+        } catch (NoSuchMethodException e) {
+            return aClass.getMethod(methodName, argTypes);
+        }
+    }
+
+    public static Method findMethod(Class<?> aClass, Class returnType, Class... argTypes) throws NoSuchMethodException {
+        List<Method> methods = findMethods(aClass, returnType, argTypes);
+        if (methods.isEmpty()) {
+            throw new NoSuchMethodException("No method matching " + returnType + " ?(" + Arrays.toString(argTypes) + ")");
+        }
+        if (methods.size() > 1) {
+            throw new NoSuchMethodException("More than 1 method matching " + returnType + " ?(" + Arrays.toString(argTypes) + ") : " + methods);
+        }
+        return methods.get(0);
+    }
+
+    public static List<Method> findMethods(Class<?> aClass, Class returnType, Class... argTypes) throws NoSuchMethodException {
+        List<Method> methods = new ArrayList<>();
+        for (Method m : aClass.getDeclaredMethods()) {
+            if (m.getReturnType() == returnType && m.getParameterTypes().length == argTypes.length) {
+                try {
+                    Method mLookup = aClass.getMethod(m.getName(), argTypes);
+                    if (mLookup != null) {
+                        methods.add(mLookup);
+                    }
+                } catch (NoSuchMethodException e) {
+                    // ignore...
+                }
+            }
+        }
+        return methods;
+    }
+
+    /**
+     * Uses reflection to execute the named method on the supplied class giving the arguments.
+     * Sinks all exceptions, but log an entry and returns <code>null</code>
+     *
+     * @param obj        The object on which to invoke the method
+     * @param methodName The name of the method to invoke
+     * @param args       The arguments to supply to the method
+     * @return <code>null</code> or the return-object from the method.
+     * @since 1.8
+     */
+    public static <T> T exec(Object obj, String methodName, Object... args) {
+        if (obj == null) {
+            return null;
+        }
+        Class[] argTypes = new Class[args.length];
+        int ix = 0;
+        for (Object arg : args) {
+            argTypes[ix++] = arg != null ? arg.getClass() : null;
+        }
+        return exec(obj, methodName, argTypes, args);
+    }
+
+    /**
+     * Returns the value of a field on the object.
+     * @param obj           The object
+     * @param fieldName     The name of the field
+     * @param <T>           The type of field
+     * @return the value or <code>null</code>
+     * @since 1.9
+     */
+    public static <T> T getField(Object obj, String fieldName) {
+        try {
+            Field field = getFieldInternal(obj, fieldName);
+            boolean wasAccessible = field.isAccessible();
+            field.setAccessible(true);
+            try {
+                return (T) field.get(obj);
+            } finally {
+                field.setAccessible(wasAccessible);
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            log.fine("Unable to find field " + fieldName + " on " + obj);
+        }
+        return null;
+    }
+
+    private static Field getFieldInternal(Object obj, String fieldName) throws NoSuchFieldException {
+        return getFieldFromClass(obj.getClass(), fieldName);
+    }
+
+    private static Field getFieldFromClass(Class<?> aClass, String fieldName) throws NoSuchFieldException {
+        if (aClass == null) {
+            throw new NoSuchFieldException("Unable to locate field " + fieldName);
+        }
+        try {
+            return aClass.getDeclaredField(fieldName);
+        } catch (NoSuchFieldException e) {
+            // Ignored
+        }
+        try {
+            return aClass.getField(fieldName);
+        } catch (NoSuchFieldException e) {
+            // Ignore
+        }
+        return getFieldFromClass(aClass.getSuperclass(), fieldName);
+    }
+
+    /**
+     * Sets the value of a field on the object.
+     * @param obj           The object
+     * @param fieldName     The name of the field
+     * @param field         The value to set
+     * @param <T>           The type of field
+     * @since 1.9
+     */
+    public static <T> void setField(Object obj, String fieldName, T field) {
+        try {
+            Field declaredField = getFieldInternal(obj, fieldName);
+            boolean wasAccessible = declaredField.isAccessible();
+            declaredField.setAccessible(true);
+            try {
+                declaredField.set(obj, field);
+            } finally {
+                declaredField.setAccessible(wasAccessible);
+            }
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            log.fine("Unable to find field " + fieldName + " on " + obj);
+        }
+    }
+
+    /**
+     * Instantiates an object.
+     * @param className The name of the class
+     * @param argTypes  An array of argument-types
+     * @param args      An array of arguments
+     * @param <T>       Return-type
+     * @return the object, or <code>null</code>.
+     * @since 1.9
+     */
+    public static <T> T newInstance(String className, Class<?>[] argTypes, Object... args) {
+        try {
+            Class<?> aClass = Class.forName(className);
+            Constructor<?> constructor = aClass.getDeclaredConstructor(argTypes);
+            return (T) constructor.newInstance(args);
+        } catch (InstantiationException | ClassNotFoundException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            log.fine("Unable to instantiate object of type " + className + ":" + e);
+        }
+        return null;
+    }
+
+    /**
+     * Instantiates an object.
+     * @param className The name of the class
+     * @param args      An array of arguments
+     * @param <T>       Return-type
+     * @return the object, or <code>null</code>.
+     * @since 1.9
+     */
+    public static <T> T newInstance(String className, Object... args) {
+        Class[] argTypes = new Class[args.length];
+        int ix = 0;
+        for (Object arg : args) {
+            argTypes[ix++] = arg != null ? arg.getClass() : null;
+        }
+        return newInstance(className, argTypes, args);
+    }
+
+    public static List<String> dumpMethods(Class aClass) {
+        List<Method> methods = Arrays.asList(aClass.getDeclaredMethods());
+        List<String> methodDescriptions = new ArrayList<>();
+        String version = getNMSVersion();
+        for (Method m : methods) {
+            List<String> parms = Arrays.asList(m.getParameterTypes()).stream().map(f -> f.getName()).collect(Collectors.toList());
+            String parmString = Arrays.toString(parms.toArray(new String[0]));
+            parmString = parmString.substring(1, parmString.length() - 1);
+            String description = (Modifier.isPublic(m.getModifiers()) ? "public " : Modifier.isPrivate(m.getModifiers()) ? "private " : "")
+                    + (Modifier.isStatic(m.getModifiers()) ? "static " : "")
+                    + m.getReturnType() + " " + m.getName()
+                    + "(" + parmString + ")";
+            description = description
+                    .replaceAll("class net.minecraft.server." + version + ".", "")
+                    .replaceAll("net.minecraft.server." + version + ".", "")
+                    .replaceAll("java.lang.", "");
+            methodDescriptions.add(description);
+        }
+        List<String> list = new ArrayList<String>();
+
+        list.add(aClass.toString().replaceAll("class net.minecraft.server." + version + ".", "")
+                .replaceAll("net.minecraft.server." + version + ".", "")
+                .replaceAll("java.lang.", "") + ":");
+        list.addAll(methodDescriptions.stream().sorted(String::compareTo).collect(Collectors.toList()));
+        return list;
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/util/FormatUtil.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/util/FormatUtil.java
@@ -1,0 +1,180 @@
+package dk.lockfuglsang.minecraft.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Format utility
+ */
+public enum FormatUtil {;
+    private static final Pattern FORMATTING = Pattern.compile("^.*(?<format>(\u00a7[0-9a-fklmor])+).*");
+    public static String stripFormatting(String format) {
+        if (format == null || format.trim().isEmpty()) {
+            return "";
+        }
+        return format.replaceAll("(\u00a7|&)[0-9a-fklmor]", "");
+    }
+
+    public static String normalize(String format) {
+        if (format == null || format.trim().isEmpty()) {
+            return "";
+        }
+        return format.replaceAll("(\u00a7|&)([0-9a-fklmor])", "\u00a7$2");
+    }
+
+    public static List<String> wordWrap(String s, int lineSize) {
+        return wordWrap(s, lineSize, lineSize);
+    }
+
+    /**
+     * Wraps the string rather lazyly around the linesize (over).
+     *
+     * I.e.
+     * <pre>
+     *   this is a line of words
+     * </pre>
+     * Will break into the following with linesize of 11:
+     * <pre>
+     *   this is a line
+     *   of words
+     * </pre>
+     * Note that the first line is longer than 11 (14).
+     */
+    public static List<String> wordWrap(String s, int firstSegment, int lineSize) {
+        String format = getFormat(s);
+        if (format == null || !s.startsWith(format)) {
+            format = "";
+        }
+        List<String> words = new ArrayList<>();
+        int numChars = firstSegment;
+        int ix = 0;
+        int jx = 0;
+        while (ix < s.length()) {
+            ix = s.indexOf(' ', ix+1);
+            if (ix != -1) {
+                String subString = s.substring(jx, ix).trim();
+                String f = getFormat(subString);
+                int chars = stripFormatting(subString).length() + 1; // remember the space
+                if (chars >= numChars) {
+                    if (f != null) {
+                        format = f;
+                    }
+                    if (!subString.isEmpty()) {
+                        words.add(withFormat(format, subString));
+                        numChars = lineSize;
+                        jx = ix + 1;
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+        words.add(withFormat(format, s.substring(jx).trim()));
+        return words;
+    }
+
+    public static List<String> wordWrapStrict(String s, int lineLength) {
+        List<String> lines = new ArrayList<>();
+        String format = getFormat(s);
+        if (format == null || !s.startsWith(format)) {
+            format = "";
+        }
+        String[] words = s.split(" ");
+        String line = "";
+        for (String word: words) {
+            String test = stripFormatting(line + " " + word).trim();
+            if (test.length() <= lineLength) {
+                // add word
+                line += (line.isEmpty() ? "" : " ") + word;
+            } else if (line.isEmpty() || stripFormatting(word).length() > lineLength) {
+                // add word truncated
+                String f = getFormat(word);
+                String strip = stripFormatting(word);
+                do {
+                    int len = Math.min(strip.length(), lineLength-line.length()-1);
+                    lines.add(withFormat(format, line + (line.isEmpty() ? "" : " ") + strip.substring(0, len)));
+                    strip = strip.substring(len);
+                    if (f != null) {
+                        format = f;
+                    }
+                } while (strip.length() > lineLength);
+                line = strip;
+            } else {
+                // add line, then start a new
+                lines.add(withFormat(format, line));
+                String f = getFormat(line);
+                if (f != null) {
+                    format = f;
+                }
+                line = word;
+            }
+        }
+        if (!line.isEmpty()) {
+            lines.add(withFormat(format, line));
+        }
+        return lines;
+    }
+
+    private static String withFormat(String format, String subString) {
+        String sf = null;
+        if (!subString.startsWith("\u00a7")) {
+            sf = format + subString;
+        } else {
+            sf = subString;
+        }
+        return sf;
+    }
+
+    private static String getFormat(String s) {
+        Matcher m = FORMATTING.matcher(s);
+        String format = null;
+        if (m.matches() && m.group("format") != null) {
+            format = m.group("format");
+        }
+        return format;
+    }
+
+    public static String join(List<String> list, String separator) {
+        String joined = "";
+        for (String s : list) {
+            joined += s + separator;
+        }
+        joined = !list.isEmpty() ? joined.substring(0, joined.length() - separator.length()) : joined;
+        return joined;
+    }
+
+    public static List<String> prefix(List<String> list, String prefix) {
+        List<String> prefixed = new ArrayList<>(list.size());
+        for (String s : list) {
+            prefixed.add(prefix + s);
+        }
+        return prefixed;
+    }
+
+    public static String camelcase(String name) {
+        if (name == null || name.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        for (String part : name.split("[ _]")) {
+            sb.append(Character.toUpperCase(part.charAt(0)));
+            sb.append(part.substring(1).toLowerCase());
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Escapes formatting by "denormalizing" back to using &amp; instead of §.
+     * @param formatString A formatstring (formerly normalized).
+     * @return A non-format string using &amp; instead of §.
+     * @since 1.10
+     */
+    public static String escape(String formatString) {
+        String escaped = normalize(formatString);
+        escaped = escaped
+                .replaceAll("\u00a7", "&");
+        return escaped;
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/util/ItemStackUtil.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/util/ItemStackUtil.java
@@ -1,0 +1,375 @@
+package dk.lockfuglsang.minecraft.util;
+
+import dk.lockfuglsang.minecraft.nbt.NBTUtil;
+import dk.lockfuglsang.minecraft.reflection.ReflectionUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static dk.lockfuglsang.minecraft.po.I18nUtil.tr;
+
+/**
+ * Conversion to ItemStack from strings.
+ */
+public enum ItemStackUtil {
+    ;
+    private static final Pattern ITEM_AMOUNT_PATTERN = Pattern.compile("(\\{p=(?<prob>0\\.[0-9]+)\\})?(?<id>[0-9A-Z_]+)(:(?<sub>[0-9]+))?:(?<amount>[0-9]+)\\s*(?<meta>\\{.*\\})?");
+    private static final Pattern ITEM_PATTERN = Pattern.compile("(?<id>[0-9A-Z_]+)(:(?<sub>[0-9]+))?\\s*(?<meta>\\{.*\\})?");
+
+    public static List<ItemProbability> createItemsWithProbabilty(List<String> items) {
+        List<ItemProbability> itemProbs = new ArrayList<>();
+        for (String reward : items) {
+            Matcher m = ITEM_AMOUNT_PATTERN.matcher(reward);
+            if (m.matches()) {
+                double p = m.group("prob") != null ? Double.parseDouble(m.group("prob")) : 1;
+                short sub = m.group("sub") != null ? (short) Integer.parseInt(m.group("sub"), 10) : 0;
+                Material type = getItemType(m, sub);
+                int amount = Integer.parseInt(m.group("amount"), 10);
+                ItemStack itemStack = new ItemStack(type, amount, sub < type.getMaxDurability() ? sub : 0);
+                itemStack = NBTUtil.addNBTTag(itemStack, m.group("meta"));
+                itemProbs.add(new ItemProbability(p, itemStack));
+            } else {
+                throw new IllegalArgumentException("Unknown item: '" + reward + "' in '" + items + "'");
+            }
+        }
+        return itemProbs;
+    }
+
+    private static Material getItemType(Matcher m, short dataValue) {
+        String id = m.group("id");
+        if (id != null && id.matches("[0-9]*")) {
+            throw new IllegalArgumentException("Bukkit 1.13+ doesn't support Item-IDs, please use Material names instead");
+        } else if (id != null) {
+            Material type = Material.matchMaterial(id);
+            if (type == null) {
+                try {
+                    Material legacyType = Material.matchMaterial(id, true);
+                    BlockData blockData = Bukkit.getServer().getUnsafe().fromLegacy(legacyType, (byte) (dataValue & 0x0f));
+                    type = blockData != null && blockData.getMaterial() != null && blockData.getMaterial() != Material.AIR
+                            ? blockData.getMaterial()
+                            : legacyType;
+                } catch (NullPointerException e) {
+                    throw new IllegalArgumentException("Bukkit 1.13 does not know the material " + id + "!", e);
+                }
+            }
+            if (type != null) {
+                return type;
+            }
+        }
+        return Material.BARRIER;
+    }
+
+    public static List<ItemStack> createItemList(List<String> items) {
+        List<ItemStack> itemList = new ArrayList<>();
+        for (String reward : items) {
+            if (reward != null && !reward.isEmpty()) {
+                itemList.add(createItemStackAmount(reward));
+            }
+        }
+        return itemList;
+    }
+
+    private static ItemStack createItemStackAmount(String reward) {
+        if (reward == null || reward.isEmpty()) {
+            return null;
+        }
+        Matcher m = ITEM_AMOUNT_PATTERN.matcher(reward);
+        if (m.matches()) {
+            short sub = m.group("sub") != null ? (short) Integer.parseInt(m.group("sub"), 10) : 0;
+            Material type = getItemType(m, sub);
+            int amount = Integer.parseInt(m.group("amount"), 10);
+            ItemStack itemStack = new ItemStack(type, amount, sub < type.getMaxDurability() ? sub : 0);
+            if (m.group("meta") != null) {
+                itemStack = NBTUtil.addNBTTag(itemStack, m.group("meta"));
+            }
+            return itemStack;
+        } else {
+            throw new IllegalArgumentException("Unknown item: '" + reward + "'");
+        }
+    }
+
+    public static ItemStack[] createItemArray(List<ItemStack> items) {
+        return items != null ? items.toArray(new ItemStack[items.size()]) : new ItemStack[0];
+    }
+
+    public static ItemStack createItemStack(String displayItem) {
+        return createItemStack(displayItem, null, null);
+    }
+
+    public static ItemStack createItemStackSkull(String texture, String name, String description) {
+        ItemStack itemStack = new ItemStack(Material.PLAYER_HEAD, 1);
+        String metaStr = String.format("{display:{Name:\"%s\"},SkullOwner:{Id:\"%s\",Properties:{textures:[{Value:\"%s\"}]}}}", name, createUniqueId(texture, name, description), texture);
+        itemStack = NBTUtil.addNBTTag(itemStack, metaStr);
+        ItemMeta meta = itemStack.getItemMeta();
+        if (meta != null) {
+            if (name != null) {
+                meta.setDisplayName(FormatUtil.normalize(name));
+            }
+            List<String> lore = new ArrayList<>();
+            if (description != null) {
+                lore.addAll(FormatUtil.wordWrap(FormatUtil.normalize(description), 30, 30));
+            }
+            meta.setLore(lore);
+            itemStack.setItemMeta(meta);
+        }
+        return itemStack;
+    }
+
+    public static UUID createUniqueId(String texture, String name, String description) {
+        return new UUID(texture.hashCode(), ("" + name + description).hashCode());
+    }
+
+    public static ItemStack createItemStack(String displayItem, String name, String description) {
+        Material type = Material.DIRT;
+        short sub = 0;
+        String metaStr = null;
+        if (displayItem != null) {
+            Matcher matcher = ITEM_PATTERN.matcher(displayItem);
+            if (matcher.matches()) {
+                sub = matcher.group("sub") != null ? (short) Integer.parseInt(matcher.group("sub"), 10) : 0;
+                type = getItemType(matcher, sub);
+                metaStr = matcher.group("meta");
+            }
+        }
+        if (type == null) {
+            Bukkit.getLogger().warning("Invalid material " + displayItem + " supplied!");
+            type = Material.BARRIER;
+        }
+        ItemStack itemStack = new ItemStack(type, 1, sub < type.getMaxDurability() ? sub : 0);
+        ItemMeta meta = itemStack.getItemMeta();
+        if (meta != null) {
+            if (name != null) {
+                meta.setDisplayName(FormatUtil.normalize(name));
+            }
+            List<String> lore = new ArrayList<>();
+            if (description != null) {
+                lore.addAll(FormatUtil.wordWrap(FormatUtil.normalize(description), 30, 30));
+            }
+            meta.setLore(lore);
+            itemStack.setItemMeta(meta);
+        }
+        itemStack = NBTUtil.addNBTTag(itemStack, metaStr);
+        return itemStack;
+    }
+
+    public static List<ItemStack> clone(List<ItemStack> items) {
+        if (items == null) {
+            return null;
+        }
+        List<ItemStack> copy = new ArrayList<>();
+        for (ItemStack item : items) {
+            copy.add(item.clone());
+        }
+        return copy;
+    }
+
+    public static boolean isValidInventoryItem(ItemStack itemStack) {
+        Inventory inventory = Bukkit.createInventory(null, 9);
+        inventory.setItem(0, itemStack);
+        return inventory.getItem(0) != null && inventory.getItem(0).getItemMeta() != null && inventory.getItem(0).getData() != null && inventory.getItem(0).getData().toItemStack() != null;
+    }
+
+    public static Builder builder(ItemStack stack) {
+        return new Builder(stack);
+    }
+
+    public static String asString(ItemStack item) {
+        return item.getType().name() + (item.getDurability() != 0 ? ":" + item.getDurability() : "") + ":" + item.getAmount();
+    }
+
+    public static String asShortString(List<ItemStack> items) {
+        List<String> shorts = new ArrayList<>();
+        for (ItemStack item : items) {
+            shorts.add(asShortString(item));
+        }
+        return  "[" + FormatUtil.join(shorts, ", ") + "]";
+    }
+
+    public static String asShortString(ItemStack item) {
+        if (item == null) {
+            return "";
+        }
+        return item.getAmount() > 1
+                ? tr("\u00a7f{0}x \u00a77{1}", item.getAmount(), getItemName(item))
+                : tr("\u00a77{0}", getItemName(item));
+    }
+
+    public static ItemStack asDisplayItem(ItemStack item) {
+        ItemStack copy = new ItemStack(item);
+        ItemMeta itemMeta = copy.getItemMeta();
+        // Hide all enchants (if possible).
+        try {
+            Class<?> aClass = Class.forName("org.bukkit.inventory.ItemFlag");
+            Object allValues = ReflectionUtil.execStatic(aClass, "values");
+            ReflectionUtil.exec(itemMeta, "addItemFlags", allValues);
+        } catch (ClassNotFoundException e) {
+            // Ignore - only available for 1.9 and above
+        }
+        copy.setItemMeta(itemMeta);
+        return copy;
+    }
+
+    public static String getItemName(ItemStack stack) {
+        if (stack != null) {
+            if (stack.getItemMeta() != null && stack.getItemMeta().getDisplayName() != null && !stack.getItemMeta().getDisplayName().trim().isEmpty()) {
+                return stack.getItemMeta().getDisplayName();
+            }
+            /*
+            Vault isn't 1.13 compatible (yet)
+            ItemInfo itemInfo = Items.itemByStack(stack);
+            return itemInfo != null ? itemInfo.getName() : "" + stack.getType();
+             */
+            return tr(FormatUtil.camelcase(stack.getType().name()).replaceAll("([A-Z])", " $1").trim());
+        }
+        return null;
+    }
+
+    /**
+     * Builder for ItemStack
+     */
+    public static class Builder {
+        private ItemStack itemStack;
+
+        public Builder(ItemStack itemStack) {
+            this.itemStack = itemStack != null ? itemStack.clone() : new ItemStack(Material.AIR);
+        }
+
+        public Builder type(Material mat) {
+            itemStack.setType(mat);
+            return this;
+        }
+
+        public Builder subType(int subType) {
+            itemStack.setDurability((short) subType);
+            return this;
+        }
+
+        public Builder amount(int amount) {
+            itemStack.setAmount(amount);
+            return this;
+        }
+
+        public Builder displayName(String name) {
+            ItemMeta itemMeta = itemStack.getItemMeta();
+            itemMeta.setDisplayName(name);
+            itemStack.setItemMeta(itemMeta);
+            return this;
+        }
+
+        public Builder enchant(Enchantment enchantment, int level) {
+            ItemMeta itemMeta = itemStack.getItemMeta();
+            itemMeta.addEnchant(enchantment, level, false);
+            itemStack.setItemMeta(itemMeta);
+            return this;
+        }
+
+        public Builder select(boolean b) {
+            return b ? select() : deselect();
+        }
+
+        public Builder select() {
+            return enchant(Enchantment.PROTECTION_ENVIRONMENTAL, 1).add(ItemFlag.HIDE_ENCHANTS);
+        }
+
+        public Builder deselect() {
+            return remove(Enchantment.PROTECTION_ENVIRONMENTAL).remove(ItemFlag.HIDE_ENCHANTS);
+        }
+
+        public Builder add(ItemFlag... flags) {
+            ItemMeta meta = itemStack.getItemMeta();
+            meta.addItemFlags(flags);
+            itemStack.setItemMeta(meta);
+            return this;
+        }
+
+        public Builder remove(ItemFlag... flags) {
+            ItemMeta meta = itemStack.getItemMeta();
+            meta.removeItemFlags(flags);
+            itemStack.setItemMeta(meta);
+            return this;
+        }
+
+        private Builder remove(Enchantment enchantment) {
+            ItemMeta itemMeta = itemStack.getItemMeta();
+            itemMeta.removeEnchant(enchantment);
+            itemStack.setItemMeta(itemMeta);
+            return this;
+        }
+
+        public Builder lore(String lore) {
+            return lore(Collections.singletonList(FormatUtil.normalize(lore)));
+        }
+
+        public Builder lore(List<String> lore) {
+            ItemMeta itemMeta = itemStack.getItemMeta();
+            if (itemMeta != null) {
+                if (itemMeta.getLore() == null) {
+                    itemMeta.setLore(lore);
+                } else {
+                    List<String> oldLore = itemMeta.getLore();
+                    oldLore.addAll(lore);
+                    itemMeta.setLore(oldLore);
+                }
+                itemStack.setItemMeta(itemMeta);
+            }
+            return this;
+        }
+
+        public ItemStack build() {
+            return itemStack;
+        }
+    }
+
+    public static class ItemProbability {
+        private final double probability;
+        private final ItemStack item;
+
+        public ItemProbability(double probability, ItemStack item) {
+            this.probability = probability;
+            this.item = item;
+        }
+
+        public double getProbability() {
+            return probability;
+        }
+
+        public ItemStack getItem() {
+            return item;
+        }
+
+        @Override
+        public String toString() {
+            return "ItemProbability{" +
+                    "probability=" + probability +
+                    ", item=" + item +
+                    '}';
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ItemProbability that = (ItemProbability) o;
+            return Double.compare(that.probability, probability) == 0 &&
+                    Objects.equals(asString(item), asString(that.item));
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(probability, item);
+        }
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/util/LocationUtil.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/util/LocationUtil.java
@@ -1,0 +1,74 @@
+package dk.lockfuglsang.minecraft.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Static convenience class for location methods.
+ */
+public enum LocationUtil {
+    ;
+    private static final Pattern LOCATION_PATTERN = Pattern.compile("((?<world>[^:/]+)[:/])?(?<x>[\\-0-9\\.]+),(?<y>[\\-0-9\\.]+),(?<z>[\\-0-9\\.]+)(:(?<yaw>[\\-0-9\\.]+):(?<pitch>[\\-0-9\\.]+))?");
+
+    public static String asString(Location loc) {
+        if (loc == null) {
+            return null;
+        }
+        String s = "";
+        if (loc.getWorld() != null && loc.getWorld().getName() != null) {
+            s += loc.getWorld().getName() + ":";
+        }
+        s += String.format(Locale.ENGLISH, "%.2f,%.2f,%.2f", loc.getX(), loc.getY(), loc.getZ());
+        if (loc.getYaw() != 0f || loc.getPitch() != 0f) {
+            s += String.format(Locale.ENGLISH, ":%.2f:%.2f", loc.getYaw(), loc.getPitch());
+        }
+        return s;
+    }
+
+    /**
+     * Convenience method for when a location is needed as a yml key.
+     */
+    public static String asKey(Location loc) {
+        return asString(loc).replaceAll(":", "/").replaceAll("\\.", "_");
+    }
+
+    public static Location fromString(String locString) {
+        if (locString == null || locString.isEmpty()) {
+            return null;
+        }
+        Matcher m = LOCATION_PATTERN.matcher(locString.replaceAll("_", "\\."));
+        if (m.matches()) {
+            return new Location(Bukkit.getWorld(m.group("world")),
+                    Double.parseDouble(m.group("x")),
+                    Double.parseDouble(m.group("y")),
+                    Double.parseDouble(m.group("z")),
+                    m.group("yaw") != null ? Float.parseFloat(m.group("yaw")) : 0,
+                    m.group("pitch") != null ? Float.parseFloat(m.group("pitch")) : 0
+            );
+        }
+        return null;
+    }
+
+    public static Location centerOnBlock(Location loc) {
+        if (loc == null) {
+            return null;
+        }
+        return new Location(loc.getWorld(),
+                loc.getBlockX() + 0.5, loc.getBlockY() + 0.1, loc.getBlockZ() + 0.5,
+                loc.getYaw(), loc.getPitch());
+    }
+
+    public static Location centerInBlock(Location loc) {
+        if (loc == null) {
+            return null;
+        }
+        return new Location(loc.getWorld(),
+                loc.getBlockX() + 0.5, loc.getBlockY() + 0.5, loc.getBlockZ() + 0.5,
+                loc.getYaw(), loc.getPitch());
+    }
+
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/util/TimeUtil.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/util/TimeUtil.java
@@ -1,0 +1,92 @@
+package dk.lockfuglsang.minecraft.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static dk.lockfuglsang.minecraft.po.I18nUtil.tr;
+
+public enum TimeUtil {
+    ;
+    private static final Pattern TIME_PATTERN = Pattern.compile("((?<d>[0-9]+)d)?\\s*((?<h>[0-9]+)h)?\\s*((?<m>[0-9]+)m)?\\s*((?<s>[0-9]+)s)?\\s*((?<ms>[0-9]+)ms)?");
+    private static final long SEC = 1000;
+    private static final long MIN = 60 * SEC;
+    private static final long HOUR = 60 * MIN;
+    private static final long DAYS = 24 * HOUR;
+
+    public static long stringAsMillis(String s) {
+        Matcher m = TIME_PATTERN.matcher(s);
+        if (m.matches()) {
+            long t = 0;
+            if (m.group("d") != null) {
+                t += Integer.parseInt(m.group("d"), 10) * DAYS;
+            }
+            if (m.group("h") != null) {
+                t += Integer.parseInt(m.group("h"), 10) * HOUR;
+            }
+            if (m.group("m") != null) {
+                t += Integer.parseInt(m.group("m"), 10) * MIN;
+            }
+            if (m.group("s") != null) {
+                t += Integer.parseInt(m.group("s"), 10) * SEC;
+            }
+            if (m.group("ms") != null) {
+                t += Integer.parseInt(m.group("ms"), 10);
+            }
+            return t;
+        }
+        return -1;
+    }
+
+    public static String millisAsString(long millis) {
+        long d = millis / DAYS;
+        long h = (millis % DAYS) / HOUR;
+        long m = (millis % HOUR) / MIN;
+        long s = (millis % MIN) / SEC;
+        String str = "";
+        if (d > 0) {
+            str += " " + d + tr("d");
+        }
+        if (h > 0) {
+            str += " " + h + tr("h");
+        }
+        if (m > 0) {
+            str += " " + m + tr("m");
+        }
+        if (s > 0 || str.isEmpty()) {
+            str += " " + s + tr("s");
+        }
+        return str.trim();
+    }
+
+    public static String millisAsShort(long millis) {
+        long m = millis / MIN;
+        long s = (millis % MIN) / SEC;
+        long ms = millis % SEC;
+        return String.format(tr("{0,number,0}:{1,number,00}.{2,number,000}", m, s, ms));
+    }
+
+    public static String ticksAsString(int ticks) {
+        return millisAsString(ticks * 50);
+    }
+
+    public static long secondsAsTicks(int secs) {
+        // 20 ticks per second = 50 ms per tick
+        return (secs * 100) / 5;
+    }
+
+    public static long secondsAsMillis(long timeout) {
+        return timeout * 1000;
+    }
+
+    public static int millisAsSeconds(long millis) {
+        return (int) Math.ceil(millis / 1000f);
+    }
+
+    public static long millisAsTicks(long ms) {
+        return ms / 50;
+    }
+
+    public static long ticksAsMillis(int ticks) {
+        return ticks * 50;
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/util/UUIDUtil.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/util/UUIDUtil.java
@@ -1,0 +1,32 @@
+package dk.lockfuglsang.minecraft.util;
+
+import java.util.UUID;
+import java.util.logging.Logger;
+
+/**
+ * Utility for handling UUIDs.
+ */
+public enum UUIDUtil {;
+    private static final Logger log = Logger.getLogger(UUIDUtil.class.getName());
+    public static UUID fromString(String id) {
+        if (id == null || id.isEmpty()) {
+            return null;
+        }
+        if (id.length() == 32) {
+            return UUID.fromString(id.substring(0, 8) + "-" + id.substring(8, 12) + "-" + id.substring(12, 16) + "-" + id.substring(16, 20) + "-" + id.substring(20, 32));
+        }
+        try {
+            return UUID.fromString(id);
+        } catch (IllegalArgumentException e) {
+            // ignore, do logging elsewhere
+        }
+        return null;
+    }
+
+    public static String asString(UUID uuid) {
+        if (uuid == null) {
+            return "";
+        }
+        return uuid.toString();
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/util/VersionUtil.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/util/VersionUtil.java
@@ -1,0 +1,75 @@
+package dk.lockfuglsang.minecraft.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Utility methods for versions
+ * @since v1.15
+ */
+public enum VersionUtil {;
+    private static final Pattern VERSION_PATTERN = Pattern.compile("v?(?<major>[0-9]+)[\\._](?<minor>[0-9]+)(?:[\\._](?<micro>[0-9]+))?(?<sub>.*)");
+    public static Version getVersion(String versionString) {
+        Matcher m = VERSION_PATTERN.matcher(versionString);
+        if (m.matches()) {
+            int major = Integer.parseInt(m.group("major"));
+            int minor = m.group("minor") != null ? Integer.parseInt(m.group("minor")) : 0;
+            int micro = m.group("micro") != null ? Integer.parseInt(m.group("micro")) : 0;
+            return new Version(major, minor, micro, m.group("sub"));
+        }
+        return new Version(0,0,0, null);
+    }
+
+    public static class Version {
+        private int major;
+        private int minor;
+        private int micro;
+        private String sub;
+
+        public Version(int major, int minor, int micro, String sub) {
+            this.major = major;
+            this.minor = minor;
+            this.micro = micro;
+            this.sub = sub;
+        }
+
+        public int getMajor() {
+            return major;
+        }
+
+        public int getMinor() {
+            return minor;
+        }
+
+        public int getMicro() {
+            return micro;
+        }
+
+        public String getSub() {
+            return sub;
+        }
+
+        public boolean isGTE(String version) {
+            Version other = getVersion(version);
+            return major > other.major ||
+                    major >= other.major && minor > other.minor ||
+                    major >= other.major && minor >= other.minor && micro >= other.micro;
+        }
+
+        public boolean isLT(String version) {
+            Version other = getVersion(version);
+            return major < other.major ||
+                    major <= other.major && minor < other.minor ||
+                    major <= other.major && minor <= other.minor && micro < other.micro;
+        }
+
+        @Override
+        public String toString() {
+            return "v" + major + "." + minor + "." + micro + (sub != null ? "-" + sub : "");
+        }
+
+        public String toReleaseString() {
+            return "v" + major + "_" + minor;
+        }
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/yml/README.md
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/yml/README.md
@@ -1,0 +1,13 @@
+# YmlConfiguration
+
+These classes enables plugins to preserve comments when handling `FileConfiguration` objects in Bukkit.
+
+## Usage
+
+```
+  FileConfiguration config = new YmlConfiguration();
+  config.load(file);
+  // Do FileConfiguration stuff
+
+  config.save(file);
+```

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/yml/YmlCommentParser.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/yml/YmlCommentParser.java
@@ -1,0 +1,215 @@
+package dk.lockfuglsang.minecraft.yml;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A very simplistic yml parser, that only do the following:
+ * <ol>
+ *     <li>Keep track of indentation-levels and sections.</li>
+ *     <li>Handle comments.</li>
+ * </ol>
+ */
+public class YmlCommentParser {
+    private static final Logger log = Logger.getLogger(YmlCommentParser.class.getName());
+    private static final Pattern SECTION_PATTERN = Pattern.compile("^(?<indent>\\s*)(?<name>[^ \\-][^:]*):(?<value>[^#]*)?(?<comment>#.*)?");
+    private static final Pattern COMMENT_PATTERN = Pattern.compile("^(?<indent>\\s*)(?<comment>#.*)");
+    private Map<String, String> commentMap = new HashMap<>();
+
+    public Map<String, String> getCommentMap() {
+        return Collections.unmodifiableMap(commentMap);
+    }
+
+
+    public void addComment(String path, String comment) {
+        commentMap.put(path, comment);
+    }
+
+    public void addComments(Map<String,String> comments) {
+        commentMap.putAll(comments);
+    }
+
+    private void readLines(BufferedReader rdr) throws IOException {
+        int indentLevel = 0;
+        Deque<Section> sections = new ArrayDeque<>();
+        StringBuilder comments = new StringBuilder();
+        String baseKey = null;
+        sections.add(new Section(null, 0));
+        String line;
+        int lineNum = 1;
+        boolean isFirstAfterSection = true;
+        while ((line = rdr.readLine()) != null) {
+            Matcher commentM = COMMENT_PATTERN.matcher(line);
+            Matcher sectionM = SECTION_PATTERN.matcher(line);
+            if (commentM.matches()) {
+                comments.append(commentM.group("comment") + "\n");
+            } else if (sectionM.matches()) {
+                String comment = sectionM.group("comment");
+                if (comment != null && !comment.trim().isEmpty()) {
+                    comments.append(comment + "\n");
+                }
+                String name = sectionM.group("name").trim();
+                String value = sectionM.group("value");
+                String indent = sectionM.group("indent");
+                if (isFirstAfterSection && indent.length() > indentLevel) {
+                    indentLevel = indent.length();
+                    sections.peek().setIndentation(indentLevel);
+                } else if (indent.length() < indentLevel) {
+                    while (indent.length() < indentLevel && !sections.isEmpty()) {
+                        sections.pop();
+                        baseKey = sections.peek().getPath();
+                        indentLevel = sections.peek().getIndentation();
+                        isFirstAfterSection = false;
+                    }
+                }
+                String path = getPath(baseKey, name);
+                if (value != null && !value.trim().isEmpty()) {
+                    // Scalar with value
+                    addComments(path, comments);
+                    if (!isFirstAfterSection && indent.length() > indentLevel) {
+                        log.warning("line " + lineNum + ": mixed indentation, expected " + indentLevel + " but got " + indent.length());
+                    }
+                    isFirstAfterSection = false;
+                } else if (indent.length() >= indentLevel) {
+                    indentLevel = indent.length();
+                    sections.push(createSection(path, indentLevel, comments));
+                    baseKey = path;
+                    isFirstAfterSection = true;
+                }
+            } else if (line.trim().isEmpty()) {
+                // Currently gathered comments are reset - they are "floating", decoupled from sections.
+                comments.setLength(0);
+                comments.trimToSize();
+            }
+            lineNum++;
+        }
+    }
+
+    private String getPath(String baseKey, String name) {
+        return baseKey != null ? baseKey + "." + name : name;
+    }
+
+    private Section createSection(String path, int indentLevel, StringBuilder comments) {
+        Section section = new Section(path, indentLevel);
+        addComments(path, comments);
+        return section;
+    }
+
+    private void addComments(String path, StringBuilder comments) {
+        if (comments.length() > 0) {
+            commentMap.put(path, comments.toString());
+            comments.setLength(0);
+            comments.trimToSize();
+        }
+    }
+
+    public String getComment(String path) {
+        return commentMap.get(path);
+    }
+
+    /**
+     * Merges the comments into the "pure" yml.
+     * @param ymlPure A YML data-tree, without comments.
+     * @return A YML data-tree including comments.
+     */
+    public String mergeComments(String ymlPure) {
+        StringBuilder sb = new StringBuilder();
+        boolean isFirstAfterSection = true;
+        Deque<Section> sections = new ArrayDeque<>();
+        sections.push(new Section(null, 0));
+        int indentLevel = 0;
+        String baseKey = null;
+        int lineNum = 1;
+        // First section shares comments with the header - so ignore that one
+        boolean isHeader = true;
+        for (String line : ymlPure.split("\n")) {
+            // Skip header
+            Matcher commentM = COMMENT_PATTERN.matcher(line);
+            if (isHeader && (commentM.matches() || line.trim().isEmpty())) {
+                continue; // Skip header
+            }
+            isHeader = false;
+            Matcher sectionM = SECTION_PATTERN.matcher(line);
+            if (sectionM.matches()) {
+                String name = sectionM.group("name").trim();
+                String value = sectionM.group("value");
+                String indent = sectionM.group("indent");
+                if (isFirstAfterSection && indent.length() > indentLevel) {
+                    indentLevel = indent.length();
+                    sections.peek().setIndentation(indentLevel);
+                } else if (indent.length() < indentLevel) {
+                    while (indent.length() < indentLevel && !sections.isEmpty()) {
+                        sections.pop();
+                        baseKey = sections.peek().getPath();
+                        indentLevel = sections.peek().getIndentation();
+                        isFirstAfterSection = false;
+                    }
+                }
+                String path = getPath(baseKey, name);
+                String comment = getComment(path);
+                if (comment != null) {
+                    sb.append((lineNum > 1 ? "\n" : "") + comment
+                            .replaceAll("^#", Matcher.quoteReplacement(indent + "#"))
+                            .replaceAll("\n#", Matcher.quoteReplacement("\n" + indent + "#")));
+                }
+                if (value != null && !value.trim().isEmpty()) {
+                    // Scalar with value
+                    isFirstAfterSection = false;
+                } else if (indent.length() >= indentLevel) {
+                    indentLevel = indent.length();
+                    sections.push(new Section(path, indentLevel));
+                    baseKey = path;
+                    isFirstAfterSection = true;
+                }
+            }
+            lineNum++;
+            sb.append(line + "\n");
+        }
+        return sb.toString().replaceAll("\r\n", "\n").replaceAll("\n\r", "\n").replaceAll("\n", "\r\n");
+    }
+
+    public void load(Reader reader) throws IOException {
+        readLines(new BufferedReader(reader));
+    }
+
+    public void loadFromString(String contents) {
+        try {
+            readLines(new BufferedReader(new StringReader(contents)));
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to read from string", e);
+        }
+    }
+
+
+    private static class Section {
+        private int indentation;
+        private final String path;
+
+        private Section(String name, int indentation) {
+            this.indentation = indentation;
+            this.path = name;
+        }
+
+        public int getIndentation() {
+            return indentation;
+        }
+
+        public String getPath() {
+            return path;
+        }
+
+        public void setIndentation(int indentLevel) {
+            indentation = indentLevel;
+        }
+    }
+}

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/yml/YmlConfiguration.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/yml/YmlConfiguration.java
@@ -1,0 +1,57 @@
+package dk.lockfuglsang.minecraft.yml;
+
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A YamlConfiguration that supports comments
+ *
+ * Note: This includes a VERY SIMPLISTIC Yaml-parser, which sole purpose is to detect and store comments.
+ */
+public class YmlConfiguration extends YamlConfiguration {
+    private YmlCommentParser commentParser = new YmlCommentParser();
+
+    public String getComment(String key) {
+        String comment = commentParser.getComment(key);
+        return comment != null ? comment.replaceAll("^# ?", "").replaceAll("\n# ?", "") : null;
+    }
+
+    public Map<String,String> getComments() {
+        return commentParser.getCommentMap();
+    }
+
+    public void addComment(String path, String comment) {
+        commentParser.addComment(path, comment);
+    }
+    public void addComments(Map<String,String> comments) {
+        commentParser.addComments(comments);
+    }
+
+    @Override
+    public void loadFromString(String contents) throws InvalidConfigurationException {
+        super.loadFromString(contents);
+        commentParser.loadFromString(contents);
+    }
+
+    @Override
+    public List<String> getStringList(String path) {
+        if (isList(path)) {
+            return super.getStringList(path);
+        } else if (isString(path)) {
+            return Arrays.asList(super.getString(path, "").split(" "));
+        }
+        return new ArrayList<>();
+    }
+
+    @Override
+    public String saveToString() {
+        String ymlPure = super.saveToString();
+        return commentParser.mergeComments(ymlPure);
+    }
+
+}

--- a/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/command/BaseCommandExecutorTest.java
+++ b/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/command/BaseCommandExecutorTest.java
@@ -1,0 +1,87 @@
+package dk.lockfuglsang.minecraft.command;
+
+import org.bukkit.command.CommandSender;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+public class BaseCommandExecutorTest {
+    StringBuffer messages = new StringBuffer();
+    private static BaseCommandExecutor mycmd;
+
+    @BeforeClass
+    public static void setUp() {
+        mycmd = new BaseCommandExecutor("mycmd", "myplugin.perm.mycmd", "main myplugin command");
+        mycmd.add(new AbstractCommand("hello|h", "myplugin.perm.hello", "say hello to the player") {
+            @Override
+            public boolean execute(CommandSender sender, String alias, Map<String, Object> data, String... args) {
+                sender.sendMessage(new String[]{
+                        "Hello! and welcome " + sender.getName(),
+                        "I was called with : " + alias,
+                        "I had " + args.length + " arguments: " + Arrays.asList(args)
+                });
+                return true;
+            }
+        });
+    }
+
+    @Test
+    public void testNoPermissions() {
+        CommandSender sender = createCommandSender();
+        mycmd.onCommand(sender, null, "mycmd", new String[]{"mycmd", "h", "your", "momma"});
+        assertThat(getMessages(), is("§eYou do not have access (§4myplugin.perm.mycmd§e)\n" +
+                "§7Usage: §3mycmd§a [command|help]§7 - §emain myplugin command"));
+    }
+
+    private String getMessages() {
+        return messages.toString().trim();
+    }
+
+    @Test
+    public void testBasic() {
+        CommandSender sender = createCommandSender();
+        addPerm(sender, "myplugin.perm.mycmd");
+        addPerm(sender, "myplugin.perm.hello");
+        mycmd.onCommand(sender, null, "mycmd", new String[]{"h", "your", "momma"});
+        assertThat(getMessages(), is("Hello! and welcome null\nI was called with : h\nI had 2 arguments: [your, momma]"));
+    }
+
+    private void addPerm(CommandSender sender, String s) {
+        when(sender.hasPermission(ArgumentMatchers.isA(String.class))).thenReturn(true);
+    }
+
+    private void addOp(CommandSender sender) {
+        when(sender.isOp()).thenReturn(true);
+    }
+
+    private CommandSender createCommandSender() {
+        CommandSender mock = Mockito.mock(CommandSender.class);
+        Answer<Void> answer = invocationOnMock -> {
+            for (Object o : invocationOnMock.getArguments()) {
+                if (o != null && o.getClass().isArray()) {
+                    for (Object o2 : (Object[]) o) {
+                        messages.append("" + o2 + "\n");
+                    }
+                } else {
+                    messages.append("" + o + "\n");
+                }
+            }
+            return null;
+        };
+        doAnswer(answer).when(mock).sendMessage(anyString());
+        doAnswer(answer).when(mock).sendMessage(Matchers.<String[]>any());
+        return mock;
+    }
+}

--- a/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/command/CompositeCommandTest.java
+++ b/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/command/CompositeCommandTest.java
@@ -1,0 +1,178 @@
+package dk.lockfuglsang.minecraft.command;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.hamcrest.Matchers;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+public class CompositeCommandTest {
+    private static UUID ownerUUID = UUID.randomUUID();
+    private static UUID adminUUID = UUID.randomUUID();
+    private static UUID modUUID = UUID.randomUUID();
+    private static BaseCommandExecutor executor;
+
+    @BeforeClass
+    public static void setupAll() {
+        executor = new BaseCommandExecutor("plugin", "plugin", null, "does stuff", ownerUUID);
+        CompositeCommand sut = new CompositeCommand("admin", "admin.admin.superadmin", null, "super important admin command", adminUUID) {
+            @Override
+            public boolean execute(CommandSender sender, String alias, Map<String, Object> data, String... args) {
+                sender.sendMessage("executed admin");
+                return super.execute(sender, alias, data, args);
+            }
+        };
+        sut.add(new AbstractCommand("sub", "perm.sub", "some sub-command") {
+            @Override
+            public boolean execute(CommandSender sender, String alias, Map<String, Object> data, String... args) {
+                sender.sendMessage("from sub");
+                return false;
+            }
+        });
+        sut.add(new AbstractCommand("sub2", "perm.sub2", "some other sub-command", "yay", null, modUUID) {
+            @Override
+            public boolean execute(CommandSender sender, String alias, Map<String, Object> data, String... args) {
+                sender.sendMessage("from sub2");
+                return false;
+            }
+        });
+        executor.add(sut);
+    }
+
+    @Test
+    public void NoPermOnBase() {
+        // Arrange
+        Player player = mock(Player.class);
+        when(player.hasPermission(anyString())).thenReturn(false);
+
+        // Act
+        executor.onCommand(player, null, "alias", new String[]{"admin",  "sub"});
+
+        verify(player).sendMessage("§eYou do not have access (§4plugin§e)");
+    }
+
+    @Test
+    public void PermOnBase() {
+        // Arrange
+        Player player = mock(Player.class);
+        when(player.hasPermission(anyString())).thenAnswer((Answer<Boolean>) invocationOnMock ->
+                invocationOnMock.getArguments()[0] == "plugin");
+
+        // Act
+        executor.onCommand(player, null, "alias", new String[]{"admin",  "sub"});
+
+        verify(player).sendMessage("§eYou do not have access (§4admin.admin.superadmin§e)");
+    }
+
+    @Test
+    public void PermOnAdmin() {
+        // Arrange
+        Player player = mock(Player.class);
+        final List<String> messages = recordMessages(player);
+        when(player.hasPermission(anyString())).thenAnswer((Answer<Boolean>) invocationOnMock ->
+                invocationOnMock.getArguments()[0] == "plugin"
+                || invocationOnMock.getArguments()[0] == "admin.admin.superadmin"
+        );
+
+        // Act
+        executor.onCommand(player, null, "alias", new String[]{"admin",  "sub"});
+
+        verify(player).sendMessage("executed admin");
+        assertThat(messages, Matchers.contains(new String[]{"executed admin", "§eYou do not have access (§4perm.sub§e)"}));
+    }
+
+    @Test
+    public void AllPerms() {
+        // Arrange
+        Player player = mock(Player.class);
+        when(player.hasPermission(anyString())).thenReturn(true);
+        final List<String> messages = recordMessages(player);
+
+        // Act
+        executor.onCommand(player, null, "alias", new String[]{"admin",  "sub"});
+
+        verify(player).sendMessage("executed admin");
+        assertThat(messages, Matchers.contains(new String[]{"executed admin", "from sub"}));
+    }
+
+    @Test
+    public void NoPerm_PermissionOverride() {
+        // Arrange
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(ownerUUID);
+        final List<String> messages = recordMessages(player);
+
+        // Act
+        executor.onCommand(player, null, "alias", new String[]{"admin",  "sub"});
+
+        assertThat(messages, Matchers.contains(new String[]{"executed admin", "from sub"}));
+    }
+
+    @Test
+    public void NoPerm_PermissionSubOverride() {
+        // Arrange
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(adminUUID);
+        final List<String> messages = recordMessages(player);
+
+        // Act
+        executor.onCommand(player, null, "alias", new String[]{"admin",  "sub"});
+
+        assertThat(messages, Matchers.contains(new String[]{"§eYou do not have access (§4plugin§e)"}));
+    }
+
+    @Test
+    public void BasePerm_PermissionCompositeOverride() {
+        // Arrange
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(adminUUID);
+        when(player.hasPermission(anyString())).thenAnswer((Answer<Boolean>) invocationOnMock ->
+                invocationOnMock.getArguments()[0] == "plugin"
+        );
+        final List<String> messages = recordMessages(player);
+
+        // Act
+        executor.onCommand(player, null, "alias", new String[]{"admin", "sub"});
+
+        assertThat(messages, Matchers.contains(new String[]{"executed admin", "from sub"}));
+    }
+
+    @Test
+    public void BasePerm_PermissionAbstractCommandOverride() {
+        // Arrange
+        Player player = mock(Player.class);
+        when(player.getUniqueId()).thenReturn(modUUID);
+        when(player.hasPermission(anyString())).thenAnswer((Answer<Boolean>) invocationOnMock ->
+                invocationOnMock.getArguments()[0] == "plugin"
+                        || invocationOnMock.getArguments()[0] == "admin.admin.superadmin"
+        );
+        final List<String> messages = recordMessages(player);
+
+        // Act
+        executor.onCommand(player, null, "alias", new String[]{"admin", "sub2"});
+
+        assertThat(messages, Matchers.contains(new String[]{"executed admin", "from sub2"}));
+    }
+
+    private List<String> recordMessages(Player player) {
+        final List<String> messages = new ArrayList<>();
+        Answer<Void> voidAnswer = i -> {
+            messages.add(String.join(" ", Arrays.asList(i.getArguments()).toArray(new String[0])));
+            return null;
+        };
+        doAnswer(voidAnswer).when(player).sendMessage(anyString());
+        return messages;
+    }
+
+}

--- a/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/command/PluginYamlCommandVisitorTest.java
+++ b/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/command/PluginYamlCommandVisitorTest.java
@@ -1,0 +1,55 @@
+package dk.lockfuglsang.minecraft.command;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class PluginYamlCommandVisitorTest {
+    @Test
+    public void writeToSimple() throws Exception {
+        PluginYamlCommandVisitor visitor = new PluginYamlCommandVisitor();
+        BaseCommandExecutor cmd = new BaseCommandExecutor("cmd|c", "plugin.cmd", "player", "some description");
+        cmd.add(new CompositeCommand("sub|s", "plugin.sub", "some sub description"));
+        cmd.add(new CompositeCommand("other", "plugin.cmd.other", "some other command"));
+        BaseCommandExecutor cmd2 = new BaseCommandExecutor("adm|a", "plugin.adm", "hey jude!");
+        cmd2.add(new CompositeCommand("subs|ss", "plugin.sub", "some other sub"));
+        cmd2.add(new CompositeCommand("t2", "plugin.cmdtest", "?optional mandatory", "test"));
+        String expected = String.join(System.lineSeparator(), Files.readAllLines(
+                Paths.get(getClass().getClassLoader().getResource("yml/pluginyml_simple.yml").toURI())));
+
+        cmd.accept(visitor);
+        cmd2.accept(visitor);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(baos);
+        visitor.writeTo(out);
+        assertThat(baos.toString(), is(expected));
+    }
+
+    @Test
+    public void writeToSimpleFeatureMap() throws Exception {
+        PluginYamlCommandVisitor visitor = new PluginYamlCommandVisitor();
+        BaseCommandExecutor cmd = new BaseCommandExecutor("cmd|c", "plugin.cmd", "some description");
+        CompositeCommand sub = new CompositeCommand("sub|s", "plugin.sub", "some sub description");
+        cmd.add(sub);
+        sub.addFeaturePermission("plugin.feature.a", "enables A");
+        sub.addFeaturePermission("plugin.feature.b", "enables B");
+        sub.addFeaturePermission("plugin.featuresub", "standalone feature");
+        cmd.add(new CompositeCommand("other", "plugin.cmd.other", "some other command"));
+        String expected = String.join(System.lineSeparator(), Files.readAllLines(
+                Paths.get(getClass().getClassLoader().getResource("yml/pluginyml_featuremap.yml").toURI())));
+
+        cmd.accept(visitor);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream out = new PrintStream(baos);
+        visitor.writeTo(out);
+        assertThat(baos.toString(), is(expected));
+    }
+}

--- a/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/file/FileUtilTest.java
+++ b/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/file/FileUtilTest.java
@@ -1,0 +1,23 @@
+package dk.lockfuglsang.minecraft.file;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+/**
+ * JUnit tests for FileUtil
+ */
+public class FileUtilTest {
+    @Test
+    public void testGetExtension() {
+        assertThat(FileUtil.getExtension("basename.ext"), is("ext"));
+        assertThat(FileUtil.getExtension("my file.with.dot.yml"), is("yml"));
+    }
+
+    @Test
+    public void testBaseName() {
+        assertThat(FileUtil.getBasename("dir/something/filename.txt"), is("filename"));
+        assertThat(FileUtil.getBasename("dir\\something\\filename.txt"), is("filename"));
+    }
+}

--- a/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/nbt/NBTUtilTest.java
+++ b/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/nbt/NBTUtilTest.java
@@ -1,0 +1,38 @@
+package dk.lockfuglsang.minecraft.nbt;
+
+import com.google.gson.Gson;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+
+import java.io.StringReader;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests the NBTUtil
+ */
+public class NBTUtilTest {
+
+    /**
+     * Tests that the JSONMap will return the proper syntax.
+     */
+    @Test
+    public void testJSONMap() {
+        String jsonString = "{\"Potion\":\"minecraft:empty\",\"CustomPotionEffects\":[{\"Id\":1},{\"Id\":2}]}";
+        Gson gson = new Gson();
+
+        Map<String, Object> map = (Map<String, Object>) gson.fromJson(new StringReader(jsonString), Map.class);
+        assertThat(map.get("Potion"), CoreMatchers.is("minecraft:empty"));
+        assertThat(map.get("CustomPotionEffects"), instanceOf(List.class));
+        assertThat(((List)map.get("CustomPotionEffects")).get(0), instanceOf(Map.class));
+    }
+
+    @Test
+    public void testGetGraftBukkitVersion() {
+        assertThat("net.minecraft.server.v1_10_R1.NBTTagString".split("\\.")[3], is("v1_10_R1"));
+    }
+}

--- a/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/util/BukkitServerMock.java
+++ b/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/util/BukkitServerMock.java
@@ -1,0 +1,135 @@
+package dk.lockfuglsang.minecraft.util;
+
+import dk.lockfuglsang.minecraft.nbt.NBTItemStackTagger;
+import dk.lockfuglsang.minecraft.nbt.NBTUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.Server;
+import org.bukkit.UnsafeValues;
+import org.bukkit.inventory.ItemFactory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.mockito.stubbing.Answer;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class BukkitServerMock {
+    public static boolean useMetaData;
+    /**
+     * Stubbing data, allows for advanced stubbing behaviour for item-meta
+     */
+    protected static Map<ItemMeta, Map<String,String>> itemMetaMap = new HashMap<>();
+    private static ItemFactory itemFactoryMock;
+
+    public static Server setupServerMock() throws NoSuchFieldException, IllegalAccessException {
+        Field server = Bukkit.class.getDeclaredField("server");
+        server.setAccessible(true);
+        Server serverMock = createServerMock();
+        server.set(null, serverMock);
+        server.setAccessible(false);
+
+        NBTUtil.setNBTItemStackTagger(new TestNBTItemStackTagger());
+        return serverMock;
+    }
+
+    public static Server createServerMock() {
+        Server serverMock = mock(Server.class);
+        itemFactoryMock = mock(ItemFactory.class);
+
+        when(itemFactoryMock.isApplicable(any(ItemMeta.class), any(Material.class)))
+                .thenReturn(true);
+
+        when(itemFactoryMock.equals(any(ItemMeta.class), any(ItemMeta.class)))
+                .thenAnswer((Answer<Boolean>) invocationOnMock -> {
+                    // Better equals for mocks?
+                    return Objects.equals("" + invocationOnMock.getArguments()[0],
+                            "" + invocationOnMock.getArguments()[1]);
+                });
+
+        when(itemFactoryMock.getItemMeta(any(Material.class)))
+                .thenAnswer((Answer<ItemMeta>) invocationOnMock -> createItemMetaStub());
+
+        when(itemFactoryMock.asMetaFor(any(ItemMeta.class), any(Material.class)))
+                .thenAnswer((Answer<ItemMeta>) invocationOnMock -> invocationOnMock.getArguments()[0] != null
+                        ? (ItemMeta) invocationOnMock.getArguments()[0]
+                        : null);
+        when(itemFactoryMock.updateMaterial(any(ItemMeta.class), any(Material.class)))
+                .thenAnswer(i -> i.getArguments()[1]);
+        when(serverMock.getItemFactory()).thenReturn(itemFactoryMock);
+
+        UnsafeValues unsafeMock = mock(UnsafeValues.class);
+        when(unsafeMock.fromLegacy(any(Material.class))).thenAnswer(a -> (Material) a.getArguments()[0]);
+        when(serverMock.getUnsafe()).thenReturn(unsafeMock);
+        return serverMock;
+    }
+
+    public static ItemMeta createItemMetaStub() {
+        if (!useMetaData) {
+            return null;
+        }
+        ItemMeta meta = mock(ItemMeta.class, withSettings().extraInterfaces(Damageable.class));
+        when(((Damageable)meta).getDamage()).thenReturn(0);
+        // Note: This is a HACKY way of stubbing, using mock and toString()
+        final Map<String, String> metaData = new TreeMap<>();
+        itemMetaMap.put(meta, metaData);
+        doAnswer((Answer<Void>) invocationOnMock -> {
+            String displayName = "" + invocationOnMock.getArguments()[0];
+            if (displayName.isEmpty()) {
+                metaData.remove("displayName");
+            } else {
+                metaData.put("displayName", "" + displayName);
+            }
+            return null;
+        }).when(meta).setDisplayName(any(String.class));
+        doAnswer((Answer<Void>) invocationOnMock -> {
+            List<String> lore = (List<String>) invocationOnMock.getArguments()[0];
+            if (lore != null && !lore.isEmpty()) {
+                metaData.put("lore", "" + lore);
+            } else {
+                metaData.remove("lore");
+            }
+            return null;
+        }).when(meta).setLore(any(List.class));
+        when(meta.toString()).thenAnswer((Answer<String>) invocationOnMock -> "" + metaData);
+        when(meta.clone()).thenReturn(meta); // Don't clone it - we need to verify it
+        return meta;
+    }
+
+    public static class TestNBTItemStackTagger implements NBTItemStackTagger {
+        @Override
+        public String getNBTTag(ItemStack itemStack) {
+            if (itemMetaMap.containsKey(itemStack.getItemMeta())) {
+                Map<String, String> metaMap = itemMetaMap.get(itemStack.getItemMeta());
+                if (metaMap.containsKey("nbt")) {
+                    return metaMap.get("nbt");
+                }
+            }
+            return "";
+        }
+
+        @Override
+        public ItemStack setNBTTag(ItemStack itemStack, String tag) {
+            ItemMeta itemMeta = itemStack.getItemMeta();
+            if (itemMeta != null && itemMetaMap.containsKey(itemMeta)) {
+                Map<String, String> metaMap = itemMetaMap.get(itemMeta);
+                metaMap.put("nbt", tag);
+                itemStack.setItemMeta(itemMeta);
+            }
+            return itemStack;
+        }
+
+        @Override
+        public ItemStack addNBTTag(ItemStack itemStack, String tag) {
+            return setNBTTag(itemStack, tag);
+        }
+    }
+}

--- a/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/util/FormatUtilTest.java
+++ b/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/util/FormatUtilTest.java
@@ -1,0 +1,67 @@
+package dk.lockfuglsang.minecraft.util;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static dk.lockfuglsang.minecraft.util.FormatUtil.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class FormatUtilTest {
+
+    @Test
+    public void testNormalize() throws Exception {
+        String input = "pre&00&11&22&33&44&55&66&77&88&99&aa&bb&cc&dd&ee&ff&ggpost";
+        String expected = "pre§00§11§22§33§44§55§66§77§88§99§aa§bb§cc§dd§ee§ff&ggpost";
+        assertThat(normalize(input), is(expected));
+    }
+
+    @Test
+    public void testWordWrap() throws Exception {
+        assertThat(wordWrap("asdadfasd asfasdfasd", 9, 12),
+                is(Arrays.asList(
+                "asdadfasd", "asfasdfasd")));
+        assertThat(wordWrap("§1Hello §2World §3How are you", 4, 10),
+                is(Arrays.asList("§1Hello", "§2World §3How", "§3are you")));
+
+        assertThat(wordWrap("§1§2§3§4§5Hello §aWorld §1§2§3§4what happens", 10, 10), is(Arrays.asList(
+            "§1§2§3§4§5Hello §aWorld", "§1§2§3§4what happens"
+        )));
+
+        assertThat(wordWrap("this is a short story of a long sentence withaverylongword in the end", 14, 14),
+                is(Arrays.asList(
+                        "this is a short",
+                        "story of a long",
+                        "sentence withaverylongword",
+                        "in the end")));
+    }
+
+    @Test
+    public void testWordWrapStrict() {
+        assertThat(wordWrapStrict("this is a short story of a long sentence withaverylongword in the end", 14),
+                is(Arrays.asList(
+                        "this is a",
+                        "short story of",
+                        "a long",
+                        "sentence witha",
+                        "verylongword",
+                        "in the end")));
+
+        assertThat(wordWrapStrict("§1Hello §2World §3How are you", 10),
+                is(Arrays.asList("§1Hello", "§2World §3How", "§3are you")));
+    }
+
+    @Test
+    public void testCapitalize() throws Exception {
+        assertThat(camelcase("SAND_CASTLE"), is("SandCastle"));
+        assertThat(camelcase("SHEEP"), is("Sheep"));
+        assertThat(camelcase("ender chest"), is("EnderChest"));
+    }
+
+    @Test
+    public void testEscape() throws Exception {
+        String text = "\u00a7eHello World\r\n\u00a7aThis is a \u00a7kmagic\r\n\u00a7lhej";
+        assertThat(escape(text), is("&eHello World\r\n&aThis is a &kmagic\r\n&lhej"));
+    }
+}

--- a/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/util/ItemStackMatcher.java
+++ b/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/util/ItemStackMatcher.java
@@ -1,0 +1,58 @@
+package dk.lockfuglsang.minecraft.util;
+
+import org.bukkit.inventory.ItemStack;
+import org.hamcrest.Description;
+import org.hamcrest.Factory;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+
+public class ItemStackMatcher extends TypeSafeDiagnosingMatcher<ItemStack> {
+
+    private final String expected;
+
+    public ItemStackMatcher(ItemStack expected) {
+        this.expected = ItemStackUtil.asString(expected);
+    }
+
+    @Override
+    protected boolean matchesSafely(ItemStack itemStack, Description description) {
+        String other = ItemStackUtil.asString(itemStack);
+        description.appendText(" was ").appendValue(other);
+        return expected.equals(other);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText(expected);
+    }
+
+    @Factory
+    public static ItemStackMatcher itemStack(ItemStack expected) {
+        return new ItemStackMatcher(expected);
+    }
+
+    @Factory
+    public static Matcher<Iterable<? extends ItemStack>> itemStacks(Collection<ItemStack> items) {
+        return itemStacks(items.toArray(new ItemStack[0]));
+    }
+
+    @Factory
+    public static Matcher<Iterable<? extends ItemStack>> itemStacks(ItemStack... items) {
+        List<Matcher<? super ItemStack>> matchers = new ArrayList();
+        ItemStack[] arr$ = items;
+        int len$ = items.length;
+
+        for(int i$ = 0; i$ < len$; ++i$) {
+            ItemStack item = arr$[i$];
+            matchers.add(itemStack(item));
+        }
+
+        return contains((List)matchers);
+    }
+}

--- a/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/util/ItemStackUtilTest.java
+++ b/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/util/ItemStackUtilTest.java
@@ -1,0 +1,254 @@
+package dk.lockfuglsang.minecraft.util;
+
+import dk.lockfuglsang.minecraft.nbt.NBTItemStackTagger;
+import dk.lockfuglsang.minecraft.nbt.NBTUtil;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.Server;
+import org.bukkit.inventory.ItemFactory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+
+import static dk.lockfuglsang.minecraft.util.ItemStackMatcher.itemStack;
+import static dk.lockfuglsang.minecraft.util.ItemStackMatcher.itemStacks;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests the utility methods of ItemStackUtil
+ */
+public class ItemStackUtilTest extends BukkitServerMock {
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        Server server = setupServerMock();
+    }
+
+    @Before
+    public void setUp() {
+        useMetaData = false;
+        itemMetaMap.clear();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createItemsWithProbabiltyNull() throws Exception {
+        ItemStackUtil.createItemsWithProbabilty(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void createItemsWithProbabiltyInvalid() throws Exception {
+        ItemStackUtil.createItemsWithProbabilty(Arrays.asList("{p:0.9}10:1"));
+    }
+
+    @Test
+    public void createItemsWithProbabilty1() throws Exception {
+        List<ItemStackUtil.ItemProbability> actual = ItemStackUtil.createItemsWithProbabilty(Arrays.asList("{p=0.9}LAVA_BUCKET:1"));
+        List<ItemStackUtil.ItemProbability> expected = Arrays.asList(
+                new ItemStackUtil.ItemProbability(0.9, new ItemStack(Material.LAVA_BUCKET, 1))
+        );
+        assertThat(actual, notNullValue());
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void createItemsWithProbabiltyN() throws Exception {
+        List<ItemStackUtil.ItemProbability> actual = ItemStackUtil.createItemsWithProbabilty(Arrays.asList(
+                "{p=0.9}LAVA_BUCKET:1",
+                "{p=0.2}STONE:2:3",
+                "{p=0.3}NETHER_BRICK_FENCE:2"
+        ));
+        List<ItemStackUtil.ItemProbability> expected = Arrays.asList(
+                new ItemStackUtil.ItemProbability(0.9, new ItemStack(Material.LAVA_BUCKET, 1)),
+                new ItemStackUtil.ItemProbability(0.2, new ItemStack(Material.STONE, 3, (short) 2)),
+                new ItemStackUtil.ItemProbability(0.3, new ItemStack(Material.NETHER_BRICK_FENCE, 2))
+        );
+        assertThat(actual, notNullValue());
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void createItemsWithProbabiltyWithNBTTag() throws Exception {
+        useMetaData = true;
+        List<ItemStackUtil.ItemProbability> actual = ItemStackUtil.createItemsWithProbabilty(Arrays.asList(
+                "{p=0.9}LAVA_BUCKET:1{Potion:Death}",
+                "{p=0.2}STONE:2:3 {MyLittle:\"Pony\"}",
+                "{p=0.3}NETHER_BRICK_FENCE:2\t {meta:{nested:{data:[{},{}]}}}"
+        ));
+        List<ItemStackUtil.ItemProbability> expected = Arrays.asList(
+                new ItemStackUtil.ItemProbability(0.9, NBTUtil.setNBTTag(
+                        new ItemStack(Material.LAVA_BUCKET, 1),
+                        "{Potion:Death}")),
+                new ItemStackUtil.ItemProbability(0.2, NBTUtil.setNBTTag(
+                        new ItemStack(Material.STONE, 3, (short) 2),
+                        "{MyLittle:\"Pony\"}")),
+                new ItemStackUtil.ItemProbability(0.3, NBTUtil.setNBTTag(
+                        new ItemStack(Material.NETHER_BRICK_FENCE, 2),
+                        "{meta:{nested:{data:[{},{}]}}}"))
+        );
+        assertThat(actual, notNullValue());
+        assertThat(actual, is(expected));
+        assertThat(NBTUtil.getNBTTag(actual.get(2).getItem()), is("{meta:{nested:{data:[{},{}]}}}"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createItemListNull() throws Exception {
+        ItemStackUtil.createItemList((List) null);
+    }
+
+    @Test
+    public void createItemListInvalid() throws Exception {
+        try {
+            ItemStackUtil.createItemList(Arrays.asList("DART"));
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage(), is("Unknown item: 'DART'"));
+        }
+    }
+
+    @Test
+    public void createItemList() throws Exception {
+        List<ItemStack> actual = ItemStackUtil.createItemList(Arrays.asList(
+                "LAVA_BUCKET:1",
+                "STONE:2:3",
+                "NETHER_BRICK_FENCE:2"
+        ));
+        List<ItemStack> expected = Arrays.asList(
+                new ItemStack(Material.LAVA_BUCKET, 1),
+                new ItemStack(Material.STONE, 3, (short) 2),
+                new ItemStack(Material.NETHER_BRICK_FENCE, 2)
+        );
+        assertThat(actual, itemStacks(expected));
+    }
+
+    @Test
+    public void createItemListStringAndListWithNBTTags() throws Exception {
+        useMetaData = true;
+        List<ItemStack> actual = ItemStackUtil.createItemList(Arrays.asList("NETHER_BRICK_FENCE:2{meta2}", "JUNGLE_WOOD:256 {meta3}"));
+        List<ItemStack> expected = Arrays.asList(
+                NBTUtil.setNBTTag(new ItemStack(Material.NETHER_BRICK_FENCE, 2), "{meta2}"),
+                NBTUtil.setNBTTag(new ItemStack(Material.JUNGLE_WOOD, 256), "{meta3}") // Jungle Wood Planks
+        );
+        assertThat(actual, is(expected));
+        assertThat(actual.get(1).getAmount(), is(256));
+        assertThat(NBTUtil.getNBTTag(actual.get(0)), is("{meta2}"));
+    }
+
+    @Test
+    public void createItemArrayNull() throws Exception {
+        ItemStack[] actual = ItemStackUtil.createItemArray(null);
+        assertThat(actual, is(new ItemStack[0]));
+    }
+
+    @Test
+    public void createItemArrayEmpty() throws Exception {
+        ItemStack[] actual = ItemStackUtil.createItemArray(Collections.<ItemStack>emptyList());
+        assertThat(actual, is(new ItemStack[0]));
+    }
+
+    @Test
+    public void createItemArray() throws Exception {
+        List<ItemStack> expected = Arrays.asList(
+                new ItemStack(Material.LAVA_BUCKET, 1),
+                new ItemStack(Material.STONE, 3, (short) 2),
+                new ItemStack(Material.NETHER_BRICK_FENCE, 2),
+                new ItemStack(Material.JUNGLE_WOOD, 256) // Jungle Wood Planks
+        );
+        ItemStack[] actual = ItemStackUtil.createItemArray(expected);
+        assertThat(actual, is(expected.toArray()));
+    }
+
+    @Test
+    @Ignore("Bukkit.getUnsafe() is not available in test-runner")
+    public void createItemStack_LegacyColor() throws Exception {
+        ItemStack actual = ItemStackUtil.createItemStack("STAINED_GLASS_PANE:14");
+        assertThat(actual.getType(), is(Material.RED_STAINED_GLASS_PANE));
+        assertThat(actual.getDurability(), is(0));
+    }
+
+    @Test
+    public void createItemStackName() throws Exception {
+        ItemStack actual = ItemStackUtil.createItemStack("DIRT");
+        ItemStack expected = new ItemStack(Material.DIRT, 1);
+        assertThat(actual, itemStack(expected));
+
+        actual = ItemStackUtil.createItemStack("STONE:2"); // Diorite
+        expected = new ItemStack(Material.STONE, 1, (short) 2);
+        assertThat(actual, itemStack(expected));
+    }
+
+    @Test
+    public void createItemStackWithMeta() throws Exception {
+        useMetaData = true;
+        ItemStack actual = ItemStackUtil.createItemStack("STONE:2", "&lMy Title", "Hello &4World");
+        ItemStack expected = new ItemStack(Material.STONE, 1, (short) 2);
+        ItemMeta itemMeta = expected.getItemMeta();
+        itemMeta.setDisplayName("\u00a7lMy Title");
+        itemMeta.setLore(Arrays.asList("Hello \u00a74World"));
+        expected.setItemMeta(itemMeta);
+
+        assertThat(actual.getItemMeta(), notNullValue());
+        verify(actual.getItemMeta()).setDisplayName("\u00a7lMy Title");
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void createItemStackWithMetaNBTTag() throws Exception {
+        useMetaData = true;
+        ItemStack actual = ItemStackUtil.createItemStack("STONE {display:{Name:\"Hi mom\"}}", "&lMy Title", "Hello &4World");
+        ItemStack expected = new ItemStack(Material.STONE, 1);
+        ItemMeta itemMeta = expected.getItemMeta();
+        itemMeta.setDisplayName("\u00a7lMy Title");
+        itemMeta.setLore(Arrays.asList("Hello \u00a74World"));
+        expected.setItemMeta(itemMeta);
+        expected = NBTUtil.setNBTTag(expected, "{display:{Name:\"Hi mom\"}}");
+
+        assertThat(actual.getItemMeta(), notNullValue());
+        verify(actual.getItemMeta()).setDisplayName("\u00a7lMy Title");
+        assertThat(actual, is(expected));
+        // Also verify the string, just to be extra sure
+        assertThat(actual.toString(), is("ItemStack{STONE x 1, {displayName=\u00a7lMy Title, lore=[Hello \u00a74World], nbt={display:{Name:\"Hi mom\"}}}}"));
+    }
+
+    @Test
+    public void testCloneNull() throws Exception {
+        List<ItemStack> clone = ItemStackUtil.clone(null);
+        assertThat(clone, nullValue());
+    }
+
+    @Test
+    public void testClone() throws Exception {
+        List<ItemStack> orig = new ArrayList<>(Arrays.asList(
+                new ItemStack(Material.LAVA, 1),
+                new ItemStack(Material.DIRT, 2),
+                new ItemStack(Material.STONE, 3)
+        ));
+        List<ItemStack> clone = ItemStackUtil.clone(orig);
+        assertThat(clone, itemStacks(orig));
+        orig.get(0).setAmount(10);
+        orig.get(1).setAmount(20);
+        orig.remove(2);
+        assertThat(clone, not(orig));
+        assertThat(clone.size(), is(3));
+        assertThat(clone.get(1).getAmount(), is(2));
+    }
+
+}

--- a/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/util/LocationUtilTest.java
+++ b/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/util/LocationUtilTest.java
@@ -1,0 +1,64 @@
+package dk.lockfuglsang.minecraft.util;
+
+import org.bukkit.Location;
+import org.bukkit.Server;
+import org.bukkit.World;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LocationUtilTest {
+    @BeforeClass
+    public static void SetupOnce() throws Exception {
+        Server server = BukkitServerMock.setupServerMock();
+        when(server.getWorld(anyString())).thenAnswer((a) -> {
+            World mock = mock(World.class);
+            when(mock.getName()).thenReturn(a.getArguments()[0].toString());
+            return mock;
+        });
+    }
+
+    @Test
+    public void asString() {
+        World world = mock(World.class);
+        when(world.getName()).thenReturn("world");
+        Location loc = new Location(world, 1.12, -34.12, 2.0);
+
+        assertThat(LocationUtil.asString(loc), is("world:1.12,-34.12,2.00"));
+    }
+
+    @Test
+    public void asKey() {
+        World world = mock(World.class);
+        when(world.getName()).thenReturn("world");
+        Location loc = new Location(world, 1.12, -34.12, 2.0);
+
+        assertThat(LocationUtil.asKey(loc), is("world/1_12,-34_12,2_00"));
+    }
+
+    @Test
+    public void fromString_asString() {
+        World world = mock(World.class);
+        when(world.getName()).thenReturn("world");
+        Location loc = new Location(world, 1.12, -34.12, 2.0);
+
+        String str = "world:1.12,-34.12,2.00";
+        assertThat(LocationUtil.asString(LocationUtil.fromString(str)), is(LocationUtil.asString(loc)));
+    }
+
+    @Test
+    public void fromString_asKey() {
+        World world = mock(World.class);
+        when(world.getName()).thenReturn("world");
+        Location loc = new Location(world, 1.12, -34.12, 2.0);
+
+        String key = "world/1_12,-34_12,2_00";
+        assertThat(LocationUtil.asString(LocationUtil.fromString(key)), is(LocationUtil.asString(loc)));
+    }
+
+}

--- a/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/yml/YmlCommentParserTest.java
+++ b/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/yml/YmlCommentParserTest.java
@@ -1,0 +1,37 @@
+package dk.lockfuglsang.minecraft.yml;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileReader;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+public class YmlCommentParserTest {
+
+    @Test
+    public void testLoad() throws Exception {
+        File simpleYml = new File(getClass().getClassLoader().getResource("yml/simple.yml").toURI());
+        YmlCommentParser parser = new YmlCommentParser();
+        parser.load(new FileReader(simpleYml));
+        assertThat(parser.getCommentMap(), notNullValue());
+        assertThat(parser.getComment(null), nullValue());
+        assertThat(parser.getComment("root"), is("#\n" +
+                "# This is a simple Yml file\n" +
+                "#\n" +
+                "# with multiple comments\n"));
+        assertThat(parser.getComment("root.child node"), is("# child nodes\n"));
+        assertThat(parser.getComment("root.a"), nullValue());
+        assertThat(parser.getComment("root.a.section"), nullValue());
+        assertThat(parser.getComment("root.a.section.deeper"), is("# a comment\n"));
+        assertThat(parser.getComment("root.a.section.deeper.b"), is("# b comment\n"));
+        assertThat(parser.getComment("root.child node.some-double"), is("# a number\n"));
+    }
+
+    @Test
+    public void testReplaceAll() {
+        String comment = "# comment\n# and comment  \n#  and...\n";
+        assertThat(comment.replaceAll("^# ?", "").replaceAll("\n# ?", "\n"), is("comment\nand comment  \n and...\n"));
+    }
+}

--- a/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/yml/YmlConfigurationTest.java
+++ b/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/yml/YmlConfigurationTest.java
@@ -1,0 +1,65 @@
+package dk.lockfuglsang.minecraft.yml;
+
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.hamcrest.MockitoHamcrest;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by R4zorax on 15/07/2016.
+ */
+public class YmlConfigurationTest {
+    @Test
+    public void saveToString() throws Exception {
+        File simpleYml = new File(getClass().getClassLoader().getResource("yml/simple.yml").toURI());
+        YmlConfiguration config = new YmlConfiguration();
+        config.load(simpleYml);
+
+        config.set("root.child node.abe", "lincoln\nwas a wonderful\npresident");
+        String expected = new String(Files.readAllBytes(Paths.get(getClass().getClassLoader().getResource("yml/simple_expected.yml").toURI())), "UTF-8");
+        assertThat(config.saveToString(), is(expected));
+    }
+
+
+    @Test
+    public void testGetStringList_Spaces() throws Exception {
+        File simpleYml = new File(getClass().getClassLoader().getResource("yml/simple.yml").toURI());
+        YmlConfiguration config = new YmlConfiguration();
+        config.load(simpleYml);
+
+        List<String> actual = config.getStringList("root.child node.some-section.space-list");
+        assertThat(actual, Matchers.contains("13:1", "34:3"));
+    }
+
+    @Test
+    public void testGetStringList_List() throws Exception {
+        File simpleYml = new File(getClass().getClassLoader().getResource("yml/simple.yml").toURI());
+        YmlConfiguration config = new YmlConfiguration();
+        config.load(simpleYml);
+
+        List<String> actual = config.getStringList("root.child node.some-section.another-list");
+        assertThat(actual, Matchers.contains("what now", "do you know?"));
+    }
+
+    @Test
+    public void testGetStringList_OneLineList() throws Exception {
+        File simpleYml = new File(getClass().getClassLoader().getResource("yml/simple.yml").toURI());
+        YmlConfiguration config = new YmlConfiguration();
+        config.load(simpleYml);
+
+        List<String> actual = config.getStringList("root.child node.some-section.section-list");
+        assertThat(actual, Matchers.contains("Hej", "Mor"));
+    }
+
+}

--- a/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/yml/YmlConfigurationTest.java
+++ b/bukkit-utils/src/test/java/dk/lockfuglsang/minecraft/yml/YmlConfigurationTest.java
@@ -1,17 +1,15 @@
 package dk.lockfuglsang.minecraft.yml;
 
-import org.bukkit.configuration.InvalidConfigurationException;
-import org.hamcrest.Matcher;
+import org.bukkit.configuration.file.YamlConfiguration;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-import org.mockito.hamcrest.MockitoHamcrest;
 
+import java.io.BufferedReader;
 import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -23,29 +21,20 @@ public class YmlConfigurationTest {
     @Test
     public void saveToString() throws Exception {
         File simpleYml = new File(getClass().getClassLoader().getResource("yml/simple.yml").toURI());
-        YmlConfiguration config = new YmlConfiguration();
+        YamlConfiguration config = new YamlConfiguration();
         config.load(simpleYml);
 
         config.set("root.child node.abe", "lincoln\nwas a wonderful\npresident");
-        String expected = new String(Files.readAllBytes(Paths.get(getClass().getClassLoader().getResource("yml/simple_expected.yml").toURI())), "UTF-8");
+        String expected = new BufferedReader(new InputStreamReader(getClass().getClassLoader().getResourceAsStream("yml/simple_expected.yml"), StandardCharsets.UTF_8))
+            .lines().collect(Collectors.joining(System.lineSeparator()));
+        config.save(new File(simpleYml.getParent(), "new_actual.yml"));
         assertThat(config.saveToString(), is(expected));
-    }
-
-
-    @Test
-    public void testGetStringList_Spaces() throws Exception {
-        File simpleYml = new File(getClass().getClassLoader().getResource("yml/simple.yml").toURI());
-        YmlConfiguration config = new YmlConfiguration();
-        config.load(simpleYml);
-
-        List<String> actual = config.getStringList("root.child node.some-section.space-list");
-        assertThat(actual, Matchers.contains("13:1", "34:3"));
     }
 
     @Test
     public void testGetStringList_List() throws Exception {
         File simpleYml = new File(getClass().getClassLoader().getResource("yml/simple.yml").toURI());
-        YmlConfiguration config = new YmlConfiguration();
+        YamlConfiguration config = new YamlConfiguration();
         config.load(simpleYml);
 
         List<String> actual = config.getStringList("root.child node.some-section.another-list");
@@ -55,11 +44,10 @@ public class YmlConfigurationTest {
     @Test
     public void testGetStringList_OneLineList() throws Exception {
         File simpleYml = new File(getClass().getClassLoader().getResource("yml/simple.yml").toURI());
-        YmlConfiguration config = new YmlConfiguration();
+        YamlConfiguration config = new YamlConfiguration();
         config.load(simpleYml);
 
         List<String> actual = config.getStringList("root.child node.some-section.section-list");
         assertThat(actual, Matchers.contains("Hej", "Mor"));
     }
-
 }

--- a/bukkit-utils/src/test/resources/yml/.gitattributes
+++ b/bukkit-utils/src/test/resources/yml/.gitattributes
@@ -1,0 +1,1 @@
+*.yml text eol=crlf

--- a/bukkit-utils/src/test/resources/yml/pluginyml_featuremap.yml
+++ b/bukkit-utils/src/test/resources/yml/pluginyml_featuremap.yml
@@ -1,0 +1,50 @@
+commands:
+  cmd:
+    description: 'some description'
+    aliases: [c]
+    permission: plugin.cmd
+permissions:
+  #
+  # Permission Groups
+  # =================
+  plugin.*:
+    children:
+      plugin.cmd: true
+      plugin.cmd.other: true
+      plugin.feature: true
+      plugin.feature.a: true
+      plugin.feature.b: true
+      plugin.featuresub: true
+      plugin.sub: true
+
+  plugin.cmd.*:
+    children:
+      plugin.cmd.other: true
+
+  plugin.feature.*:
+    children:
+      plugin.feature.a: true
+      plugin.feature.b: true
+
+  #
+  # Permission Descriptions
+  # =======================
+  plugin.cmd:
+    description: 'Grants access to /cmd - some description'
+
+  plugin.cmd.other:
+    description: 'Grants access to /cmd other - some other command'
+
+  plugin.feature.a:
+    description: 'enables A'
+
+  plugin.feature.b:
+    description: 'enables B'
+
+  plugin.featuresub:
+    description: 'standalone feature'
+
+  plugin.sub:
+    description: 'Grants access to /cmd sub - some sub description'
+
+

--- a/bukkit-utils/src/test/resources/yml/pluginyml_simple.yml
+++ b/bukkit-utils/src/test/resources/yml/pluginyml_simple.yml
@@ -1,0 +1,46 @@
+commands:
+  cmd:
+    description: 'some description'
+    aliases: [c]
+    permission: plugin.cmd
+  adm:
+    description: 'hey jude!'
+    aliases: [a]
+    permission: plugin.adm
+permissions:
+  #
+  # Permission Groups
+  # =================
+  plugin.*:
+    children:
+      plugin.adm: true
+      plugin.cmd: true
+      plugin.cmd.other: true
+      plugin.cmdtest: true
+      plugin.sub: true
+
+  plugin.cmd.*:
+    children:
+      plugin.cmd.other: true
+
+  #
+  # Permission Descriptions
+  # =======================
+  plugin.adm:
+    description: 'Grants access to /adm - hey jude!'
+
+  plugin.cmd:
+    description: 'Grants access to /cmd <player> - some description'
+
+  plugin.cmd.other:
+    description: 'Grants access to /cmd <player> other - some other command'
+
+  plugin.cmdtest:
+    description: 'Grants access to /adm t2 [optional] <mandatory> - test'
+
+  plugin.sub:
+    description: |
+      Grants access to /cmd <player> sub - some sub description
+      /adm subs - some other sub
+
+

--- a/bukkit-utils/src/test/resources/yml/simple.yml
+++ b/bukkit-utils/src/test/resources/yml/simple.yml
@@ -1,0 +1,25 @@
+#
+# This is a simple Yml file
+#
+# with multiple comments
+root:
+  child-value: 10
+
+  # child nodes
+  child node:
+      some-double: 1.34  # a number
+      some-section:
+        section-list: [Hej, Mor]
+        another-list:
+          - what now
+          - do you know?
+        space-list: '13:1 34:3'
+      # this is a key and a value
+      key: 'value'
+  another node:
+    enabled: true
+  # a comment
+  a.section.deeper:
+    b: # b comment
+      c: false # should be false
+"an.annoying:key this.is:for.sure": hello world

--- a/bukkit-utils/src/test/resources/yml/simple_expected.yml
+++ b/bukkit-utils/src/test/resources/yml/simple_expected.yml
@@ -1,0 +1,44 @@
+#
+# This is a simple Yml file
+#
+# with multiple comments
+root:
+  child-value: 10
+
+  # child nodes
+  child node:
+
+    # a number
+    some-double: 1.34
+    some-section:
+      section-list:
+      - Hej
+      - Mor
+      another-list:
+      - what now
+      - do you know?
+      space-list: 13:1 34:3
+
+    # this is a key and a value
+    key: value
+    abe: |-
+      lincoln
+      was a wonderful
+      president
+  another node:
+    enabled: true
+  a:
+    section:
+
+      # a comment
+      deeper:
+
+        # b comment
+        b:
+
+          # should be false
+          c: false
+an:
+  annoying:key this:
+    is:for:
+      sure: hello world

--- a/bukkit-utils/src/test/resources/yml/simple_expected.yml
+++ b/bukkit-utils/src/test/resources/yml/simple_expected.yml
@@ -4,12 +4,10 @@
 # with multiple comments
 root:
   child-value: 10
-
+  
   # child nodes
   child node:
-
-    # a number
-    some-double: 1.34
+    some-double: 1.34 # a number
     some-section:
       section-list:
       - Hej
@@ -18,7 +16,6 @@ root:
       - what now
       - do you know?
       space-list: 13:1 34:3
-
     # this is a key and a value
     key: value
     abe: |-
@@ -29,16 +26,12 @@ root:
     enabled: true
   a:
     section:
-
       # a comment
       deeper:
-
-        # b comment
-        b:
-
-          # should be false
-          c: false
+        b: # b comment
+          c: false # should be false
 an:
   annoying:key this:
     is:for:
       sure: hello world
+

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
         <jbannotations.version>23.0.0</jbannotations.version>
         <maven-artifact.version>3.8.6</maven-artifact.version>
         <api.version>${project.version}</api.version>
-        <bukkit-utils.version>1.25-SNAPSHOT</bukkit-utils.version>
         <paperlib.version>1.0.8</paperlib.version>
         <spigotapi.version>1.20.4-R0.1-SNAPSHOT</spigotapi.version>
         <vault.version>1.7</vault.version>
@@ -41,6 +40,7 @@
 
     <modules>
         <module>po-utils</module>
+        <module>bukkit-utils</module>
         <module>uSkyBlock-API</module>
         <module>uSkyBlock-APIv2</module>
         <module>uSkyBlock-Core</module>
@@ -177,28 +177,6 @@
     </pluginRepositories>
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>dk.lockfuglsang.minecraft</groupId>
-                <artifactId>bukkit-utils</artifactId>
-                <version>${bukkit-utils.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>dk.lockfuglsang.minecraft</groupId>
-                        <artifactId>po-utils</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.bukkit</groupId>
-                        <artifactId>bukkit</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>dk.lockfuglsang.minecraft</groupId>
-                <artifactId>bukkit-utils</artifactId>
-                <version>${bukkit-utils.version}</version>
-                <scope>test</scope>
-                <classifier>tests</classifier>
-            </dependency>
             <dependency>
                 <groupId>net.milkbowl.vault</groupId>
                 <artifactId>VaultAPI</artifactId>

--- a/uSkyBlock-Core/pom.xml
+++ b/uSkyBlock-Core/pom.xml
@@ -82,7 +82,7 @@
                             <minimizeJar>true</minimizeJar>
                             <artifactSet>
                                 <includes>
-                                    <include>dk.lockfuglsang.minecraft:bukkit-utils</include>
+                                    <include>ovh.uskyblock:bukkit-utils</include>
                                     <include>io.papermc:paperlib</include>
                                     <include>org.bstats:*</include>
                                     <include>ovh.uskyblock:po-utils</include>
@@ -341,14 +341,16 @@
 
     <dependencies>
         <dependency>
-            <groupId>dk.lockfuglsang.minecraft</groupId>
+            <groupId>ovh.uskyblock</groupId>
             <artifactId>bukkit-utils</artifactId>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
-        <dependency>
-            <groupId>dk.lockfuglsang.minecraft</groupId>
+         <dependency>
+            <groupId>ovh.uskyblock</groupId>
             <artifactId>bukkit-utils</artifactId>
-            <scope>test</scope>
-            <classifier>tests</classifier>
+            <version>3.1.0-SNAPSHOT</version>
+             <type>test-jar</type>
+             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ovh.uskyblock</groupId>


### PR DESCRIPTION
Merges https://github.com/uskyblock/bukkit-utils into the main repository as a separate maven module.

This has many advantages:
- It is easy to keep spigot/bukkit versions in sync
- The two are tightly integrated, and therefore development is much more streamelined
- Logically, they both belong to the same project as neither exists without the other
- bukkit utils depends on po utils, which are already merged into the main plugin. We therefore have a cyclic dependency between projects.
- It is easy to see which parts of bukkit-utils are still in use, and which are redundant and can be removed

Note: this merge should compile, but is untested. Merging the 1.20.6 update #55, which depends on this merge, will result in a runnable plugin.