### PR TITLE
Fix blocks being converted into items when computing the island level

### DIFF
--- a/uSkyBlock-API/src/main/java/us/talabrek/ultimateskyblock/api/model/BlockScore.java
+++ b/uSkyBlock-API/src/main/java/us/talabrek/ultimateskyblock/api/model/BlockScore.java
@@ -1,6 +1,8 @@
 package us.talabrek.ultimateskyblock.api.model;
 
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.inventory.ItemStack;
 
 /**
@@ -14,8 +16,25 @@ public interface BlockScore {
      *
      * @return The type of block.
      * @since v2.1.2
+     * @deprecated Converting a BlockData to an ItemStack is not supported in Minecraft. Use #getBlockData() instead.
      */
-    ItemStack getBlock();
+    @Deprecated(since = "v3.1.0")
+    default ItemStack getBlock() {
+        Material material = getBlockData().getMaterial();
+        if (material.isItem()) {
+            return new ItemStack(material);
+        } else {
+            throw new UnsupportedOperationException("BlockData is not an item. Use getBlockData() instead.");
+        }
+    }
+
+    /**
+     * The type of block.
+     *
+     * @return The type of block.
+     * @since v3.1.0
+     */
+    BlockData getBlockData();
 
     /**
      * The number of blocks of this type found on the island.

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/InfoCommand.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/InfoCommand.java
@@ -5,6 +5,7 @@ import org.bukkit.entity.Player;
 import us.talabrek.ultimateskyblock.Settings;
 import us.talabrek.ultimateskyblock.api.async.Callback;
 import us.talabrek.ultimateskyblock.api.model.BlockScore;
+import us.talabrek.ultimateskyblock.api.model.IslandScore;
 import us.talabrek.ultimateskyblock.island.IslandInfo;
 import us.talabrek.ultimateskyblock.player.PatienceTester;
 import us.talabrek.ultimateskyblock.player.PlayerInfo;
@@ -65,7 +66,7 @@ public class InfoCommand extends RequireIslandCommand {
             return false;
         }
         final PlayerInfo playerInfo = islandPlayer.equals(player.getName()) ? plugin.getPlayerInfo(player) : plugin.getPlayerInfo(islandPlayer);
-        final Callback<us.talabrek.ultimateskyblock.api.model.IslandScore> showInfo = new Callback<us.talabrek.ultimateskyblock.api.model.IslandScore>() {
+        final Callback<IslandScore> showInfo = new Callback<>() {
             @Override
             public void run() {
                 if (player.isOnline()) {
@@ -82,8 +83,8 @@ public class InfoCommand extends RequireIslandCommand {
                         player.sendMessage(tr("Score Count Block"));
                         for (BlockScore score : getState().getTop((currentPage - 1) * 10, 10)) {
                             player.sendMessage(score.getState().getColor() + tr("{0,number,00.00}  {1,number,#} {2}",
-                                    score.getScore(), score.getCount(),
-                                    ItemStackUtil.getItemName(score.getBlock())));
+                                score.getScore(), score.getCount(),
+                                ItemStackUtil.getBlockName(score.getBlockData())));
                         }
                         player.sendMessage(tr("\u00a7aIsland level is {0,number,###.##}", getState().getScore()));
                     }
@@ -101,6 +102,4 @@ public class InfoCommand extends RequireIslandCommand {
         }, 1L);
         return true;
     }
-
-
 }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/BlockLimitLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/BlockLimitLogic.java
@@ -61,7 +61,7 @@ public class BlockLimitLogic {
     private Map<Material, Integer> asBlockCount(IslandScore score) {
         Map<Material, Integer> countMap = new ConcurrentHashMap<>();
         for (BlockScore blockScore : score.getTop()) {
-            Material type = blockScore.getBlock().getType();
+            Material type = blockScore.getBlockData().getMaterial();
             if (blockLimits.containsKey(type)) {
                 int initalValue = countMap.getOrDefault(type, 0);
                 initalValue += blockScore.getCount();

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/BlockLevelConfig.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/BlockLevelConfig.java
@@ -60,7 +60,7 @@ public class BlockLevelConfig {
             adjustedCount = dReturns(adjustedCount, diminishingReturns);
         }
         double blockScore = adjustedCount * scorePerBlock;
-        return new BlockScoreImpl(baseBlock.asItemStack(), count, blockScore/pointsPerLevel, state);
+        return new BlockScoreImpl(baseBlock.getType().createBlockData(), count, blockScore/pointsPerLevel, state);
     }
 
     private double dReturns(final double val, final double scale) {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/BlockMatch.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/BlockMatch.java
@@ -1,7 +1,6 @@
 package us.talabrek.ultimateskyblock.island.level;
 
 import org.bukkit.Material;
-import org.bukkit.inventory.ItemStack;
 
 /**
  * Holds the identification of a unit to be matched against a block
@@ -15,10 +14,6 @@ public class BlockMatch implements Comparable<BlockMatch> {
 
     public Material getType() {
         return type;
-    }
-
-    public ItemStack asItemStack() {
-        return new ItemStack(type, 1);
     }
 
     public boolean matches(Material material) {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/BlockScoreComparator.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/BlockScoreComparator.java
@@ -16,7 +16,7 @@ public class BlockScoreComparator implements Comparator<BlockScore> {
             cmp = o2.getCount() - o1.getCount();
         }
         if (cmp == 0) {
-            cmp = ItemStackUtil.getItemName(o2.getBlock()).compareTo(ItemStackUtil.getItemName(o1.getBlock()));
+            cmp = ItemStackUtil.getBlockName(o2.getBlockData()).compareTo(ItemStackUtil.getBlockName(o1.getBlockData()));
         }
         return cmp;
     }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/BlockScoreImpl.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/BlockScoreImpl.java
@@ -1,26 +1,26 @@
 package us.talabrek.ultimateskyblock.island.level;
 
 import dk.lockfuglsang.minecraft.util.ItemStackUtil;
-import org.bukkit.inventory.ItemStack;
+import org.bukkit.block.data.BlockData;
 
 
 public class BlockScoreImpl implements us.talabrek.ultimateskyblock.api.model.BlockScore {
-    private final ItemStack block;
+    private final BlockData block;
     private final int count;
     private final double score;
     private final State state;
     private final String name;
 
-    public BlockScoreImpl(ItemStack block, int count, double score, State state) {
+    public BlockScoreImpl(BlockData block, int count, double score, State state) {
         this(block, count, score, state, null);
     }
 
-    public BlockScoreImpl(ItemStack block, int count, double score, State state, String name) {
+    public BlockScoreImpl(BlockData block, int count, double score, State state, String name) {
         this.block = block;
         this.count = count;
         this.score = score;
         this.state = state;
-        this.name = name != null ? name : ItemStackUtil.getItemName(getBlock());
+        this.name = name != null ? name : ItemStackUtil.getBlockName(getBlockData());
     }
 
     @Override
@@ -34,9 +34,8 @@ public class BlockScoreImpl implements us.talabrek.ultimateskyblock.api.model.Bl
                 '}';
     }
 
-
     @Override
-    public ItemStack getBlock() {
+    public BlockData getBlockData() {
         return block;
     }
 

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/IslandScore.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/IslandScore.java
@@ -3,7 +3,6 @@ package us.talabrek.ultimateskyblock.island.level;
 import us.talabrek.ultimateskyblock.api.model.BlockScore;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +41,7 @@ public class IslandScore implements us.talabrek.ultimateskyblock.api.model.Islan
         if (score.getState().ordinal() > existing.getState().ordinal()) {
             state = existing.getState();
         }
-        return new BlockScoreImpl(existing.getBlock(),
+        return new BlockScoreImpl(existing.getBlockData(),
                 score.getCount() + existing.getCount(),
                 score.getScore() + existing.getScore(), state, score.getName());
     }
@@ -70,7 +69,7 @@ public class IslandScore implements us.talabrek.ultimateskyblock.api.model.Islan
             throw new IllegalArgumentException("Offset must be a non-negative integer.");
         }
         if (!isSorted) {
-            Collections.sort(top, new BlockScoreComparator());
+            top.sort(new BlockScoreComparator());
             isSorted = true;
         }
         return top.subList(offset, Math.min(offset+num, top.size()));


### PR DESCRIPTION
This is no longer supported in Minecraft 1.21 for materials that cannot be items such as lava or potted plants. Fixes #62