### PR TITLE
Fix wither spawning with disabled spawn-limits

### DIFF
--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/event/SpawnEvents.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/event/SpawnEvents.java
@@ -1,6 +1,5 @@
 package us.talabrek.ultimateskyblock.event;
 
-import dk.lockfuglsang.minecraft.po.I18nUtil;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -10,7 +9,6 @@ import org.bukkit.entity.Ghast;
 import org.bukkit.entity.Phantom;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.WaterMob;
-import org.bukkit.entity.Wither;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
@@ -21,8 +19,6 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.MonsterEggs;
 import org.bukkit.material.SpawnEgg;
-import org.bukkit.metadata.FixedMetadataValue;
-import us.talabrek.ultimateskyblock.api.IslandInfo;
 import us.talabrek.ultimateskyblock.handler.WorldGuardHandler;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 import us.talabrek.ultimateskyblock.util.LocationUtil;
@@ -103,13 +99,6 @@ public class SpawnEvents implements Listener {
             if (isDeepOceanBiome(loc) && isPrismarineRoof(loc)) {
                 loc.getWorld().spawnEntity(loc, EntityType.GUARDIAN);
                 event.setCancelled(true);
-            }
-        }
-        if (event.getSpawnReason() == CreatureSpawnEvent.SpawnReason.BUILD_WITHER && event.getEntity() instanceof Wither) {
-            IslandInfo islandInfo = plugin.getIslandInfo(event.getLocation());
-            if (islandInfo != null && islandInfo.getLeader() != null) {
-                event.getEntity().setCustomName(I18nUtil.tr("{0}''s Wither", islandInfo.getLeader()));
-                event.getEntity().setMetadata("fromIsland", new FixedMetadataValue(plugin, islandInfo.getName()));
             }
         }
     }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/event/WitherTagListener.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/event/WitherTagListener.java
@@ -1,0 +1,34 @@
+package us.talabrek.ultimateskyblock.event;
+
+import dk.lockfuglsang.minecraft.po.I18nUtil;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Wither;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.persistence.PersistentDataType;
+import us.talabrek.ultimateskyblock.api.IslandInfo;
+import us.talabrek.ultimateskyblock.uSkyBlock;
+
+public class WitherTagListener implements Listener {
+
+    static final String ENTITY_ORIGIN_METADATA = "from-island";
+    private final uSkyBlock plugin;
+
+    public WitherTagListener(uSkyBlock plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onCreatureSpawn(CreatureSpawnEvent event) {
+        if (event.getSpawnReason() == CreatureSpawnEvent.SpawnReason.BUILD_WITHER
+            && event.getEntity() instanceof Wither wither) {
+            IslandInfo islandInfo = plugin.getIslandInfo(event.getLocation());
+            if (islandInfo != null && islandInfo.getLeader() != null) {
+                wither.setCustomName(I18nUtil.tr("{0}''s Wither", islandInfo.getLeader()));
+                NamespacedKey key = new NamespacedKey(plugin, ENTITY_ORIGIN_METADATA);
+                wither.getPersistentDataContainer().set(key, PersistentDataType.STRING, islandInfo.getName());
+            }
+        }
+    }
+}

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/uSkyBlock.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/uSkyBlock.java
@@ -48,16 +48,7 @@ import us.talabrek.ultimateskyblock.command.IslandCommand;
 import us.talabrek.ultimateskyblock.command.admin.DebugCommand;
 import us.talabrek.ultimateskyblock.command.admin.SetMaintenanceCommand;
 import us.talabrek.ultimateskyblock.command.island.BiomeCommand;
-import us.talabrek.ultimateskyblock.event.ExploitEvents;
-import us.talabrek.ultimateskyblock.event.GriefEvents;
-import us.talabrek.ultimateskyblock.event.InternalEvents;
-import us.talabrek.ultimateskyblock.event.ItemDropEvents;
-import us.talabrek.ultimateskyblock.event.MenuEvents;
-import us.talabrek.ultimateskyblock.event.NetherTerraFormEvents;
-import us.talabrek.ultimateskyblock.event.PlayerEvents;
-import us.talabrek.ultimateskyblock.event.SpawnEvents;
-import us.talabrek.ultimateskyblock.event.ToolMenuEvents;
-import us.talabrek.ultimateskyblock.event.WorldGuardEvents;
+import us.talabrek.ultimateskyblock.event.*;
 import us.talabrek.ultimateskyblock.handler.AsyncWorldEditHandler;
 import us.talabrek.ultimateskyblock.handler.ConfirmHandler;
 import us.talabrek.ultimateskyblock.handler.CooldownHandler;
@@ -334,6 +325,7 @@ public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManage
         manager.registerEvents(new PlayerEvents(this), this);
         manager.registerEvents(new MenuEvents(this), this);
         manager.registerEvents(new ExploitEvents(this), this);
+        manager.registerEvents(new WitherTagListener(this), this);
         if (getConfig().getBoolean("options.protection.enabled", true)) {
             manager.registerEvents(new GriefEvents(this), this);
             if (getConfig().getBoolean("options.protection.item-drops", true)) {


### PR DESCRIPTION
Resolves #60 

Decouples wither-origin tracking and spawn limit listeners. The issue was that withers were tagged with their origin island in the creature spawn listeners of SpawnEvents, which is not registered if spawn limits are disabled. I solved this by moving the wither tagging logic into a separate listener that is always active. Untagged Withers are despawned by the GriefEvents listener.

I also migrated the tagging to PDC to make it consistent without relying on name tagging, which is prone to errors.