### PR TITLE
Fix item enchant not being actually applied to the items in the challenge menu

### DIFF
--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java
@@ -15,6 +15,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import us.talabrek.ultimateskyblock.api.event.MemberJoinedEvent;
@@ -410,7 +411,8 @@ public class ChallengeLogic implements Listener {
             lores.add(tr("\u00a74\u00a7lYou can't repeat this challenge."));
         }
         if (completion.getTimesCompleted() > 0) {
-            meta.addEnchant(Enchantment.LOYALTY, 0, true);
+            meta.addEnchant(Enchantment.LOYALTY, 1, true);
+            meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         }
         meta.setLore(lores);
         currentChallengeItem.setItemMeta(meta);


### PR DESCRIPTION
Completed challenges are usually shown with an enchant glowing effect when they are completed at least once. This may be useful for the player, but the "enchanted" status of the item is also [used in the ChallengeLogic](https://github.com/uskyblock/uSkyBlock/blob/11f78a2cddca8bc0ca271da721b6172e95d5c970/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java#L509) to determine if a challenge with `offset: -1` is displayed or not, in place of the completed one.

New MC version, with the new data component system, does not allow an enchant level of 0 (even with unsafe enchant level), an is silently ignored (see decompiled source from Paper: **net.minecraft.world.item.enchantment.ItemEnchantments.Mutable#set** ).

This commit changes the enchant level to 1, and adds a flag to the item meta to hide the enchant information from the tooltip.