### PR TITLE
Fix Issue with Spaces in Challenge Names

### DIFF
--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java
@@ -190,6 +190,7 @@ public class ChallengeLogic implements Listener {
     }
 
     public Challenge getChallenge(String challengeName) {
+        challengeName = challengeName.replaceAll(" ", "");
         List<Challenge> partialMatch = new ArrayList<>();
         for (Rank rank : ranks.values()) {
             for (Challenge challenge : rank.getChallenges()) {


### PR DESCRIPTION
While using the plugin, I encountered an issue where challenge names containing spaces caused unexpected behavior. To resolve this, I implemented a fix that removes all spaces from the name before processing.