### PR TITLE
Update to multiverse-core and multiverse-inventories 5.1.1

### DIFF
--- a/uSkyBlock-Core/pom.xml
+++ b/uSkyBlock-Core/pom.xml
@@ -335,6 +335,13 @@
         </profile>
     </profiles>
 
+    <repositories>
+        <repository>
+            <id>onarandombodx</id>
+            <url>https://repo.onarandombox.com/content/groups/public/</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>ovh.uskyblock</groupId>
@@ -388,9 +395,9 @@
         </dependency>
         <!-- Multiverse -->
         <dependency>
-            <groupId>com.onarandombox.multiversecore</groupId>
-            <artifactId>Multiverse-Core</artifactId>
-            <version>4.3.1</version>
+            <groupId>org.mvplugins.multiverse.core</groupId>
+            <artifactId>multiverse-core</artifactId>
+            <version>5.1.1</version>
             <scope>provided</scope>
             <optional>true</optional>
             <exclusions>
@@ -401,9 +408,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.onarandombox.multiverseinventories</groupId>
-            <artifactId>Multiverse-Inventories</artifactId>
-            <version>4.2.3</version>
+            <groupId>org.mvplugins.multiverse.inventories</groupId>
+            <artifactId>multiverse-inventories</artifactId>
+            <version>5.1.1</version>
             <scope>provided</scope>
             <optional>true</optional>
             <exclusions>

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/hook/world/MultiverseHook.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/hook/world/MultiverseHook.java
@@ -1,16 +1,18 @@
 package us.talabrek.ultimateskyblock.hook.world;
 
-import com.onarandombox.MultiverseCore.MultiverseCore;
-import com.onarandombox.MultiverseCore.api.MultiverseWorld;
-import com.onarandombox.multiverseinventories.MultiverseInventories;
-import com.onarandombox.multiverseinventories.WorldGroup;
-import com.onarandombox.multiverseinventories.profile.WorldGroupManager;
-import com.onarandombox.multiverseinventories.share.Sharables;
 import org.bukkit.Location;
 import org.bukkit.World;
-import org.bukkit.WorldType;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
+import org.mvplugins.multiverse.core.MultiverseCore;
+import org.mvplugins.multiverse.core.MultiverseCoreApi;
+import org.mvplugins.multiverse.core.world.MultiverseWorld;
+import org.mvplugins.multiverse.core.world.WorldManager;
+import org.mvplugins.multiverse.inventories.MultiverseInventories;
+import org.mvplugins.multiverse.inventories.MultiverseInventoriesApi;
+import org.mvplugins.multiverse.inventories.profile.group.WorldGroup;
+import org.mvplugins.multiverse.inventories.profile.group.WorldGroupManager;
+import org.mvplugins.multiverse.inventories.share.Sharables;
 import us.talabrek.ultimateskyblock.Settings;
 import us.talabrek.ultimateskyblock.hook.PluginHook;
 import us.talabrek.ultimateskyblock.uSkyBlock;
@@ -64,15 +66,19 @@ public class MultiverseHook extends PluginHook {
             return;
         }
 
-        if (!mvCore.getMVWorldManager().isMVWorld(world)) {
-            mvCore.getMVWorldManager().addWorld(world.getName(), World.Environment.NORMAL,
-                "0", WorldType.NORMAL, false, GENERATOR_NAME, false);
+        WorldManager mvWorldManager = MultiverseCoreApi.get().getWorldManager();
+
+        if (!mvWorldManager.isWorld(world.getName())) {
+            //mvWorldManager.addWorld(world.getName(), World.Environment.NORMAL,
+            //    "0", WorldType.NORMAL, false, GENERATOR_NAME, false);
+            // The new MV API doesn't seem to provide methods to import a World when it is already loaded by the server.
+            plugin.getLogger().severe("the Skyblock overworld is loaded by the server but not found throught the Multiverse-core API");
         }
 
-        MultiverseWorld mvWorld = mvCore.getMVWorldManager().getMVWorld(world);
-        mvWorld.setEnvironment(World.Environment.NORMAL);
-        mvWorld.setScaling(1.0);
-        mvWorld.setGenerator(GENERATOR_NAME);
+        MultiverseWorld mvWorld = mvWorldManager.getWorld(world).get();
+        //mvWorld.setEnvironment(World.Environment.NORMAL);
+        mvWorld.setScale(1.0);
+        //mvWorld.setGenerator(GENERATOR_NAME);
 
         if (Settings.general_spawnSize > 0 && LocationUtil.isEmptyLocation(mvWorld.getSpawnLocation())) {
             Location spawn = LocationUtil.centerOnBlock(
@@ -83,7 +89,7 @@ public class MultiverseHook extends PluginHook {
         }
 
         if (!Settings.extras_sendToSpawn) {
-            mvWorld.setRespawnToWorld(mvWorld.getName());
+            mvWorld.setRespawnWorld(mvWorld);
         }
     }
 
@@ -96,15 +102,19 @@ public class MultiverseHook extends PluginHook {
             return;
         }
 
-        if (!mvCore.getMVWorldManager().isMVWorld(world)) {
-            mvCore.getMVWorldManager().addWorld(world.getName(), World.Environment.NETHER,
-                "0", WorldType.NORMAL, false, GENERATOR_NAME, false);
+        WorldManager mvWorldManager = MultiverseCoreApi.get().getWorldManager();
+
+        if (!mvWorldManager.isWorld(world.getName())) {
+            //mvWorldManager.addWorld(world.getName(), World.Environment.NETHER,
+            //    "0", WorldType.NORMAL, false, GENERATOR_NAME, false);
+            // The new MV API doesn't seem to provide methods to import a World when it is already loaded by the server.
+            plugin.getLogger().severe("the Skyblock nether is loaded by the server but not found throught the Multiverse-core API");
         }
 
-        MultiverseWorld mvWorld = mvCore.getMVWorldManager().getMVWorld(world);
-        mvWorld.setEnvironment(World.Environment.NETHER);
-        mvWorld.setScaling(1.0);
-        mvWorld.setGenerator(GENERATOR_NAME);
+        MultiverseWorld mvWorld = mvWorldManager.getWorld(world).get();
+        //mvWorld.setEnvironment(World.Environment.NETHER);
+        mvWorld.setScale(1.0);
+        //mvWorld.setGenerator(GENERATOR_NAME);
         if (Settings.general_spawnSize > 0 && LocationUtil.isEmptyLocation(mvWorld.getSpawnLocation())) {
             Location spawn = LocationUtil.centerOnBlock(
                 new Location(world, 0.5, Settings.island_height/2.0 + 0.1, 0.5));
@@ -114,7 +124,7 @@ public class MultiverseHook extends PluginHook {
         }
 
         if (!Settings.extras_sendToSpawn) {
-            mvWorld.setRespawnToWorld(plugin.getWorldManager().getWorld().getName());
+            mvWorld.setRespawnWorld(plugin.getWorldManager().getWorld().getName());
         }
 
         linkNetherInventory(plugin.getWorldManager().getWorld(), world);
@@ -125,7 +135,7 @@ public class MultiverseHook extends PluginHook {
             return;
         }
 
-        WorldGroupManager groupManager = mvInventories.getGroupManager();
+        WorldGroupManager groupManager = MultiverseInventoriesApi.get().getWorldGroupManager();
         WorldGroup worldGroup = groupManager.getGroup("skyblock");
         if (worldGroup == null) {
             worldGroup = groupManager.newEmptyGroup("skyblock");


### PR DESCRIPTION
Multiverse plugins has updated their major version from 4 to 5, with some breaking API changes.

Server owners that have updated their Multiverse will have their uSkyblock plugin not working properly with various NoClassDefFoundError.

I have made some changes to the plugin to use the new Multiverse version.

For now, the changes I made are minimal and only allow the plugin to be compiled, I still have some tests to run.