### PR TITLE
Migrate challenge progress storage to SQLite

### DIFF
--- a/buildSrc/src/main/kotlin/buildlogic.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/buildlogic.java-conventions.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 
 repositories {
     mavenLocal()
+    mavenCentral()
     maven {
         url = uri("https://hub.spigotmc.org/nexus/content/repositories/public")
     }
@@ -39,10 +40,6 @@ repositories {
 
     maven {
         url = uri("https://www.uskyblock.ovh/maven/uskyblock/")
-    }
-
-    maven {
-        url = uri("https://repo.maven.apache.org/maven2/")
     }
 
     maven {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ org-mockito-mockito-core = "5.23.0"
 org-mvplugins-multiverse-core-multiverse-core = "5.1.1"
 org-mvplugins-multiverse-inventories-multiverse-inventories = "5.1.1"
 org-spigotmc-spigot-api = "1.21.10-R0.1-SNAPSHOT"
+org-xerial-sqlite-jdbc = "3.51.2.0"
 
 [libraries]
 be-maximvdw-mvdwplaceholderapi = { module = "be.maximvdw:MVdWPlaceholderAPI", version.ref = "be-maximvdw-mvdwplaceholderapi" }
@@ -68,6 +69,7 @@ org-mockito-mockito-core = { module = "org.mockito:mockito-core", version.ref = 
 org-mvplugins-multiverse-core-multiverse-core = { module = "org.mvplugins.multiverse.core:multiverse-core", version.ref = "org-mvplugins-multiverse-core-multiverse-core" }
 org-mvplugins-multiverse-inventories-multiverse-inventories = { module = "org.mvplugins.multiverse.inventories:multiverse-inventories", version.ref = "org-mvplugins-multiverse-inventories-multiverse-inventories" }
 org-spigotmc-spigot-api = { module = "org.spigotmc:spigot-api", version.ref = "org-spigotmc-spigot-api" }
+org-xerial-sqlite-jdbc = { module = "org.xerial:sqlite-jdbc", version.ref = "org-xerial-sqlite-jdbc" }
 
 [plugins]
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }

--- a/uSkyBlock-Core/build.gradle.kts
+++ b/uSkyBlock-Core/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     testImplementation(libs.net.kyori.adventure.text.minimessage)
     testImplementation(libs.net.kyori.adventure.text.serializer.legacy)
     testImplementation(libs.org.apache.commons.commons.lang3)
+    implementation(libs.org.xerial.sqlite.jdbc)
     implementation(libs.net.kyori.adventure.text.serializer.plain)
     compileOnly(libs.net.milkbowl.vault.vaultapi)
     compileOnly(libs.org.spigotmc.spigot.api)
@@ -334,7 +335,8 @@ tasks.processResources {
         "adventureBukkitVersion" to libs.versions.net.kyori.adventure.platform.bukkit.get(),
         "apacheCommonsVersion" to libs.versions.org.apache.commons.commons.lang3.get(),
         "apacheHttpVersion" to libs.versions.org.apache.httpcomponents.httpclient.get(),
-        "mavenArtifactVersion" to libs.versions.org.apache.maven.maven.artifact.get()
+        "mavenArtifactVersion" to libs.versions.org.apache.maven.maven.artifact.get(),
+        "sqliteVersion" to libs.versions.org.xerial.sqlite.jdbc.get()
     )
     inputs.properties(props)
     filesMatching("plugin.yml") {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/bootstrap/SkyblockModule.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/bootstrap/SkyblockModule.java
@@ -81,7 +81,7 @@ public class SkyblockModule extends AbstractModule {
         @PluginDataDir Path pluginDataDir,
         Logger logger
     ) {
-        return new SqliteChallengeProgressRepository(pluginDataDir.resolve("challenge-progress.db"), logger);
+        return new SqliteChallengeProgressRepository(pluginDataDir.resolve("data").resolve("challenge-progress.db"), logger);
     }
 
     @Provides

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/bootstrap/SkyblockModule.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/bootstrap/SkyblockModule.java
@@ -11,6 +11,8 @@ import us.talabrek.ultimateskyblock.SkyUpdateChecker;
 import us.talabrek.ultimateskyblock.api.plugin.UpdateChecker;
 import us.talabrek.ultimateskyblock.config.PluginConfig;
 import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigs;
+import us.talabrek.ultimateskyblock.challenge.ChallengeProgressRepository;
+import us.talabrek.ultimateskyblock.challenge.SqliteChallengeProgressRepository;
 import us.talabrek.ultimateskyblock.handler.placeholder.MVdWPlaceholderAPI;
 import us.talabrek.ultimateskyblock.handler.placeholder.MvdwPlacehoderProvider;
 import us.talabrek.ultimateskyblock.handler.placeholder.PlaceholderAPI;
@@ -71,6 +73,15 @@ public class SkyblockModule extends AbstractModule {
     @Singleton
     public static @NotNull AnimationHandler provideAnimationHandler(Plugin plugin) {
         return new AnimationHandler(plugin);
+    }
+
+    @Provides
+    @Singleton
+    public static @NotNull ChallengeProgressRepository provideChallengeProgressRepository(
+        @PluginDataDir Path pluginDataDir,
+        Logger logger
+    ) {
+        return new SqliteChallengeProgressRepository(pluginDataDir.resolve("challenge-progress.db"), logger);
     }
 
     @Provides

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogic.java
@@ -25,17 +25,20 @@ import java.util.logging.Level;
  */
 public class ChallengeCompletionLogic {
     private final uSkyBlock plugin;
+    private final ChallengeLogic challengeLogic;
     private final ChallengeProgressRepository repository;
     private final Path legacyStorageDir;
     private final boolean legacyPlayerSharingConfigured;
     private final LoadingCache<IslandKey, Map<ChallengeKey, ChallengeCompletion>> completionCache;
 
     public ChallengeCompletionLogic(
+        ChallengeLogic challengeLogic,
         uSkyBlock plugin,
         RuntimeConfigs runtimeConfigs,
         FileConfiguration config,
         ChallengeProgressRepository repository
     ) {
+        this.challengeLogic = challengeLogic;
         this.plugin = plugin;
         this.repository = repository;
         this.legacyStorageDir = plugin.getDataFolder().toPath().resolve("completion");
@@ -60,12 +63,12 @@ public class ChallengeCompletionLogic {
         if (!Files.exists(legacyStorageDir)) {
             legacyStorageDir.toFile().mkdirs();
         }
-        new ChallengeProgressMigration(plugin, repository).migrateLegacyDataEagerly();
+        new ChallengeProgressMigration(plugin, challengeLogic, repository).migrateLegacyDataEagerly();
     }
 
     private Map<ChallengeKey, ChallengeCompletion> loadOrPopulateProgress(IslandKey islandKey) {
         Map<ChallengeKey, ChallengeCompletion> challengeMap = new HashMap<>();
-        plugin.getChallengeLogic().populateChallenges(challengeMap);
+        challengeLogic.populateChallenges(challengeMap);
         challengeMap.putAll(repository.load(islandKey));
         return challengeMap;
     }
@@ -89,7 +92,6 @@ public class ChallengeCompletionLogic {
         if (challenges.containsKey(id)) {
             ChallengeCompletion completion = challenges.get(id);
             if (!completion.isOnCooldown()) {
-                ChallengeLogic challengeLogic = plugin.getChallengeLogic();
                 Duration resetDuration = challengeLogic.getChallengeById(id).orElseThrow().getResetDuration();
                 if (resetDuration.isPositive()) {
                     Instant now = Instant.now();
@@ -125,7 +127,7 @@ public class ChallengeCompletionLogic {
 
     public void resetAllChallenges(PlayerInfo playerInfo) {
         Map<ChallengeKey, ChallengeCompletion> challengeMap = new HashMap<>();
-        plugin.getChallengeLogic().populateChallenges(challengeMap);
+        challengeLogic.populateChallenges(challengeMap);
         IslandKey islandKey = getIslandKey(playerInfo);
         completionCache.put(islandKey, challengeMap);
     }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogic.java
@@ -4,27 +4,19 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
 import org.jetbrains.annotations.NotNull;
-import us.talabrek.ultimateskyblock.island.IslandKey;
 import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigs;
-import us.talabrek.ultimateskyblock.island.IslandInfo;
+import us.talabrek.ultimateskyblock.island.IslandKey;
 import us.talabrek.ultimateskyblock.player.PlayerInfo;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 
@@ -32,12 +24,10 @@ import java.util.logging.Level;
  * Responsible for handling ChallengeCompletions
  */
 public class ChallengeCompletionLogic {
-
     private final uSkyBlock plugin;
     private final ChallengeProgressRepository repository;
     private final Path legacyStorageDir;
     private final boolean legacyPlayerSharingConfigured;
-    private final Set<IslandKey> initializedOwners = ConcurrentHashMap.newKeySet();
     private final LoadingCache<IslandKey, Map<ChallengeKey, ChallengeCompletion>> completionCache;
 
     public ChallengeCompletionLogic(
@@ -70,6 +60,11 @@ public class ChallengeCompletionLogic {
         if (!Files.exists(legacyStorageDir)) {
             legacyStorageDir.toFile().mkdirs();
         }
+        Map<IslandKey, Map<ChallengeKey, ChallengeCompletion>> migratedProgress =
+            new ChallengeProgressMigration(plugin, repository).migrateLegacyDataEagerly();
+        for (Map.Entry<IslandKey, Map<ChallengeKey, ChallengeCompletion>> entry : migratedProgress.entrySet()) {
+            completionCache.put(entry.getKey(), entry.getValue());
+        }
     }
 
     private Map<ChallengeKey, ChallengeCompletion> loadOrPopulateProgress(IslandKey islandKey) {
@@ -79,40 +74,18 @@ public class ChallengeCompletionLogic {
         return challengeMap;
     }
 
-    private Map<ChallengeKey, ChallengeCompletion> loadFromConfiguration(ConfigurationSection root) {
-        Map<ChallengeKey, ChallengeCompletion> challengeMap = new HashMap<>();
-        if (root != null) {
-            for (String challengeName : root.getKeys(false)) {
-                long firstCompleted = root.getLong(challengeName + ".firstCompleted", 0);
-                Instant firstCompletedDuration = firstCompleted > 0 ? Instant.ofEpochMilli(firstCompleted) : null;
-                ChallengeKey challengeId = ChallengeKey.of(challengeName);
-                challengeMap.put(challengeId, new ChallengeCompletion(
-                    challengeId,
-                    firstCompletedDuration,
-                    root.getInt(challengeName + ".timesCompleted", 0),
-                    root.getInt(challengeName + ".timesCompletedSinceTimer", 0)
-                ));
-            }
-        }
-        return challengeMap;
-    }
-
     public Map<ChallengeKey, ChallengeCompletion> getIslandChallenges(String islandName) {
         if (islandName == null) {
             return new HashMap<>();
         }
-        IslandKey islandKey = IslandKey.fromIslandName(islandName);
-        ensureInitialized(islandKey, null);
-        return getCachedChallenges(islandKey);
+        return getCachedChallenges(IslandKey.fromIslandName(islandName));
     }
 
     public Map<ChallengeKey, ChallengeCompletion> getChallenges(PlayerInfo playerInfo) {
         if (playerInfo == null || !playerInfo.getHasIsland() || playerInfo.locationForParty() == null) {
             return new HashMap<>();
         }
-        IslandKey islandKey = getIslandKey(playerInfo);
-        ensureInitialized(islandKey, playerInfo);
-        return getCachedChallenges(islandKey);
+        return getCachedChallenges(getIslandKey(playerInfo));
     }
 
     public void completeChallenge(PlayerInfo playerInfo, ChallengeKey id) {
@@ -158,7 +131,6 @@ public class ChallengeCompletionLogic {
         Map<ChallengeKey, ChallengeCompletion> challengeMap = new HashMap<>();
         plugin.getChallengeLogic().populateChallenges(challengeMap);
         IslandKey islandKey = getIslandKey(playerInfo);
-        initializedOwners.add(islandKey);
         completionCache.put(islandKey, challengeMap);
     }
 
@@ -187,87 +159,6 @@ public class ChallengeCompletionLogic {
         } catch (ExecutionException e) {
             plugin.getLogger().log(Level.WARNING, "Error fetching challenge-completion for id " + islandKey.value(), e);
             return new HashMap<>();
-        }
-    }
-
-    private void ensureInitialized(@NotNull IslandKey islandKey, PlayerInfo playerInfo) {
-        if (initializedOwners.contains(islandKey)) {
-            return;
-        }
-        if (repository.hasProgress(islandKey)) {
-            initializedOwners.add(islandKey);
-            return;
-        }
-
-        Map<ChallengeKey, ChallengeCompletion> imported = loadOrPopulateProgress(islandKey);
-        boolean migrated = importLegacyFileProgress(islandKey, imported);
-        if (!migrated && playerInfo != null) {
-            migrated = importLegacyPlayerProgress(playerInfo, imported);
-        }
-        if (migrated) {
-            repository.replace(islandKey, imported);
-            completionCache.put(islandKey, imported);
-        }
-        initializedOwners.add(islandKey);
-    }
-
-    private boolean importLegacyPlayerProgress(@NotNull PlayerInfo playerInfo, @NotNull Map<ChallengeKey, ChallengeCompletion> current) {
-        Map<ChallengeKey, ChallengeCompletion> imported = loadFromConfiguration(playerInfo.getConfig().getConfigurationSection("player.challenges"));
-        if (imported.isEmpty()) {
-            return false;
-        }
-        current.putAll(imported);
-        playerInfo.getConfig().set("player.challenges", null);
-        playerInfo.save();
-        plugin.getLogger().info("Migrated legacy player challenge progress for " + playerInfo.getPlayerName() + ".");
-        return true;
-    }
-
-    private boolean importLegacyFileProgress(@NotNull IslandKey islandKey, @NotNull Map<ChallengeKey, ChallengeCompletion> current) {
-        Path islandFile = legacyStorageDir.resolve(islandKey.value() + ".yml");
-        if (Files.exists(islandFile)) {
-            Map<ChallengeKey, ChallengeCompletion> imported = loadLegacyFile(islandFile.toFile());
-            current.putAll(imported);
-            backupLegacyFile(islandFile);
-            plugin.getLogger().info("Migrated legacy island challenge progress for " + islandKey.value() + ".");
-            return true;
-        }
-
-        IslandInfo islandInfo = plugin.getIslandInfo(islandKey.value());
-        if (islandInfo != null && islandInfo.getLeaderUniqueId() != null) {
-            Path leaderFile = legacyStorageDir.resolve(islandInfo.getLeaderUniqueId() + ".yml");
-            if (Files.exists(leaderFile)) {
-                Map<ChallengeKey, ChallengeCompletion> imported = loadLegacyFile(leaderFile.toFile());
-                current.putAll(imported);
-                backupLegacyFile(leaderFile);
-                plugin.getLogger().info("Migrated legacy leader challenge progress for " + islandKey.value() + ".");
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private @NotNull Map<ChallengeKey, ChallengeCompletion> loadLegacyFile(@NotNull File configFile) {
-        FileConfiguration fileConfiguration = YamlConfiguration.loadConfiguration(configFile);
-        if (fileConfiguration.getRoot() == null) {
-            return Collections.emptyMap();
-        }
-        return loadFromConfiguration(fileConfiguration.getRoot());
-    }
-
-    private void backupLegacyFile(@NotNull Path source) {
-        try {
-            Path backupDir = legacyStorageDir.resolve("legacy-backup");
-            Files.createDirectories(backupDir);
-            Path target = backupDir.resolve(source.getFileName());
-            int suffix = 1;
-            while (Files.exists(target)) {
-                target = backupDir.resolve(source.getFileName().toString().replace(".yml", "-" + suffix + ".yml"));
-                suffix++;
-            }
-            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
-        } catch (Exception e) {
-            plugin.getLogger().log(Level.WARNING, "Unable to back up legacy challenge progress file " + source, e);
         }
     }
 }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogic.java
@@ -4,22 +4,27 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
-import dk.lockfuglsang.minecraft.file.FileUtil;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.jetbrains.annotations.NotNull;
+import us.talabrek.ultimateskyblock.island.IslandKey;
 import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigs;
 import us.talabrek.ultimateskyblock.island.IslandInfo;
 import us.talabrek.ultimateskyblock.player.PlayerInfo;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 
 import java.io.File;
-import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 
@@ -29,82 +34,58 @@ import java.util.logging.Level;
 public class ChallengeCompletionLogic {
 
     private final uSkyBlock plugin;
-    private final File storageFolder;
-    private final boolean storeOnIsland;
-    private final LoadingCache<String, Map<ChallengeKey, ChallengeCompletion>> completionCache;
+    private final ChallengeProgressRepository repository;
+    private final Path legacyStorageDir;
+    private final boolean legacyPlayerSharingConfigured;
+    private final Set<IslandKey> initializedOwners = ConcurrentHashMap.newKeySet();
+    private final LoadingCache<IslandKey, Map<ChallengeKey, ChallengeCompletion>> completionCache;
 
-    public ChallengeCompletionLogic(uSkyBlock plugin, RuntimeConfigs runtimeConfigs, FileConfiguration config) {
+    public ChallengeCompletionLogic(
+        uSkyBlock plugin,
+        RuntimeConfigs runtimeConfigs,
+        FileConfiguration config,
+        ChallengeProgressRepository repository
+    ) {
         this.plugin = plugin;
-        storeOnIsland = config.getString("challengeSharing", "island").equalsIgnoreCase("island");
+        this.repository = repository;
+        this.legacyStorageDir = plugin.getDataFolder().toPath().resolve("completion");
+        legacyPlayerSharingConfigured = config.getString("challengeSharing", "island").equalsIgnoreCase("player");
+        if (legacyPlayerSharingConfigured) {
+            plugin.getLogger().warning("Legacy challengeSharing=player is deprecated. Challenge progress will be migrated to island-owned database records.");
+        }
         completionCache = CacheBuilder
             .from(runtimeConfigs.current().advanced().completionCacheSpec())
-            .removalListener((RemovalListener<String, Map<ChallengeKey, ChallengeCompletion>>) removal -> saveToFile(removal.getKey(), removal.getValue()))
+            .removalListener((RemovalListener<IslandKey, Map<ChallengeKey, ChallengeCompletion>>) removal -> {
+                if (removal.getKey() != null && removal.getValue() != null) {
+                    repository.replace(removal.getKey(), removal.getValue());
+                }
+            })
             .build(new CacheLoader<>() {
                        @Override
-                       public @NotNull Map<ChallengeKey, ChallengeCompletion> load(@NotNull String id) {
-                           return loadFromFile(id);
+                       public @NotNull Map<ChallengeKey, ChallengeCompletion> load(@NotNull IslandKey id) {
+                           return loadOrPopulateProgress(id);
                        }
                    }
             );
-        storageFolder = new File(plugin.getDataFolder(), "completion");
-        if (!storageFolder.exists() || !storageFolder.isDirectory()) {
-            storageFolder.mkdirs();
+        if (!Files.exists(legacyStorageDir)) {
+            legacyStorageDir.toFile().mkdirs();
         }
     }
 
-    private void saveToFile(String id, Map<ChallengeKey, ChallengeCompletion> map) {
-        File configFile = new File(storageFolder, id + ".yml");
-        FileConfiguration fileConfiguration = new YamlConfiguration();
-        saveToConfiguration(fileConfiguration, map);
-        try {
-            fileConfiguration.save(configFile);
-        } catch (IOException e) {
-            plugin.getLogger().log(Level.WARNING, "Unable to store challenge-completion to " + configFile, e);
-        }
-    }
-
-    private void saveToConfiguration(FileConfiguration configuration, Map<ChallengeKey, ChallengeCompletion> map) {
-        for (Map.Entry<ChallengeKey, ChallengeCompletion> entry : map.entrySet()) {
-            String challengeName = entry.getKey().id();
-            ChallengeCompletion completion = entry.getValue();
-            ConfigurationSection section = configuration.createSection(challengeName);
-            Instant cooldownUntil = completion.cooldownUntil();
-            Long cooldown = cooldownUntil != null ? cooldownUntil.toEpochMilli() : null;
-            section.set("firstCompleted", cooldown);
-            section.set("timesCompleted", completion.getTimesCompleted());
-            section.set("timesCompletedSinceTimer", completion.getTimesCompletedInCooldown());
-        }
-    }
-
-    private Map<ChallengeKey, ChallengeCompletion> loadFromFile(String id) {
-        File configFile = new File(storageFolder, id + ".yml");
-        if (!configFile.exists() && storeOnIsland) {
-            IslandInfo islandInfo = plugin.getIslandInfo(id);
-            if (islandInfo != null && islandInfo.getLeader() != null && islandInfo.getLeaderUniqueId() != null) {
-                File leaderFile = new File(storageFolder, islandInfo.getLeaderUniqueId().toString() + ".yml");
-                if (leaderFile.exists()) {
-                    leaderFile.renameTo(configFile);
-                }
-            }
-        }
-        if (configFile.exists()) {
-            FileConfiguration fileConfiguration = new YamlConfiguration();
-            FileUtil.readConfig(fileConfiguration, configFile);
-            if (fileConfiguration.getRoot() != null) {
-                return loadFromConfiguration(fileConfiguration.getRoot());
-            }
-        }
-        return new HashMap<>();
+    private Map<ChallengeKey, ChallengeCompletion> loadOrPopulateProgress(IslandKey islandKey) {
+        Map<ChallengeKey, ChallengeCompletion> challengeMap = new HashMap<>();
+        plugin.getChallengeLogic().populateChallenges(challengeMap);
+        challengeMap.putAll(repository.load(islandKey));
+        return challengeMap;
     }
 
     private Map<ChallengeKey, ChallengeCompletion> loadFromConfiguration(ConfigurationSection root) {
         Map<ChallengeKey, ChallengeCompletion> challengeMap = new HashMap<>();
-        plugin.getChallengeLogic().populateChallenges(challengeMap);
         if (root != null) {
-            for (ChallengeKey challengeId : challengeMap.keySet()) {
-                String challengeName = challengeId.id();
+            for (String challengeName : root.getKeys(false)) {
                 long firstCompleted = root.getLong(challengeName + ".firstCompleted", 0);
                 Instant firstCompletedDuration = firstCompleted > 0 ? Instant.ofEpochMilli(firstCompleted) : null;
+                ChallengeKey challengeId = ChallengeKey.of(challengeName);
                 challengeMap.put(challengeId, new ChallengeCompletion(
                     challengeId,
                     firstCompletedDuration,
@@ -117,42 +98,21 @@ public class ChallengeCompletionLogic {
     }
 
     public Map<ChallengeKey, ChallengeCompletion> getIslandChallenges(String islandName) {
-        if (storeOnIsland && islandName != null) {
-            try {
-                return completionCache.get(islandName);
-            } catch (ExecutionException e) {
-                plugin.getLogger().log(Level.WARNING, "Error fetching challenge-completion for id " + islandName);
-            }
+        if (islandName == null) {
+            return new HashMap<>();
         }
-        return new HashMap<>();
+        IslandKey islandKey = IslandKey.fromIslandName(islandName);
+        ensureInitialized(islandKey, null);
+        return getCachedChallenges(islandKey);
     }
 
     public Map<ChallengeKey, ChallengeCompletion> getChallenges(PlayerInfo playerInfo) {
         if (playerInfo == null || !playerInfo.getHasIsland() || playerInfo.locationForParty() == null) {
             return new HashMap<>();
         }
-        String id = getCacheId(playerInfo);
-        Map<ChallengeKey, ChallengeCompletion> challengeMap = new HashMap<>();
-        try {
-            challengeMap = completionCache.get(id);
-        } catch (ExecutionException e) {
-            plugin.getLogger().log(Level.WARNING, "Error fetching challenge-completion for id " + id);
-        }
-        if (challengeMap.isEmpty()) {
-            // Fetch from the player-yml file
-            challengeMap = loadFromConfiguration(playerInfo.getConfig().getConfigurationSection("player.challenges"));
-            if (!challengeMap.isEmpty()) {
-                completionCache.put(id, challengeMap);
-            }
-            // Wipe it
-            playerInfo.getConfig().set("player.challenges", null);
-            playerInfo.save();
-        }
-        return challengeMap;
-    }
-
-    private String getCacheId(PlayerInfo playerInfo) {
-        return storeOnIsland ? playerInfo.locationForParty() : playerInfo.getUniqueId().toString();
+        IslandKey islandKey = getIslandKey(playerInfo);
+        ensureInitialized(islandKey, playerInfo);
+        return getCachedChallenges(islandKey);
     }
 
     public void completeChallenge(PlayerInfo playerInfo, ChallengeKey id) {
@@ -197,11 +157,14 @@ public class ChallengeCompletionLogic {
     public void resetAllChallenges(PlayerInfo playerInfo) {
         Map<ChallengeKey, ChallengeCompletion> challengeMap = new HashMap<>();
         plugin.getChallengeLogic().populateChallenges(challengeMap);
-        completionCache.put(getCacheId(playerInfo), challengeMap);
+        IslandKey islandKey = getIslandKey(playerInfo);
+        initializedOwners.add(islandKey);
+        completionCache.put(islandKey, challengeMap);
     }
 
     public void shutdown() {
         flushCache();
+        repository.shutdown();
     }
 
     public long flushCache() {
@@ -211,6 +174,100 @@ public class ChallengeCompletionLogic {
     }
 
     public boolean isIslandSharing() {
-        return storeOnIsland;
+        return true;
+    }
+
+    private @NotNull IslandKey getIslandKey(@NotNull PlayerInfo playerInfo) {
+        return IslandKey.fromIslandName(playerInfo.locationForParty());
+    }
+
+    private @NotNull Map<ChallengeKey, ChallengeCompletion> getCachedChallenges(@NotNull IslandKey islandKey) {
+        try {
+            return completionCache.get(islandKey);
+        } catch (ExecutionException e) {
+            plugin.getLogger().log(Level.WARNING, "Error fetching challenge-completion for id " + islandKey.value(), e);
+            return new HashMap<>();
+        }
+    }
+
+    private void ensureInitialized(@NotNull IslandKey islandKey, PlayerInfo playerInfo) {
+        if (initializedOwners.contains(islandKey)) {
+            return;
+        }
+        if (repository.hasProgress(islandKey)) {
+            initializedOwners.add(islandKey);
+            return;
+        }
+
+        Map<ChallengeKey, ChallengeCompletion> imported = loadOrPopulateProgress(islandKey);
+        boolean migrated = importLegacyFileProgress(islandKey, imported);
+        if (!migrated && playerInfo != null) {
+            migrated = importLegacyPlayerProgress(playerInfo, imported);
+        }
+        if (migrated) {
+            repository.replace(islandKey, imported);
+            completionCache.put(islandKey, imported);
+        }
+        initializedOwners.add(islandKey);
+    }
+
+    private boolean importLegacyPlayerProgress(@NotNull PlayerInfo playerInfo, @NotNull Map<ChallengeKey, ChallengeCompletion> current) {
+        Map<ChallengeKey, ChallengeCompletion> imported = loadFromConfiguration(playerInfo.getConfig().getConfigurationSection("player.challenges"));
+        if (imported.isEmpty()) {
+            return false;
+        }
+        current.putAll(imported);
+        playerInfo.getConfig().set("player.challenges", null);
+        playerInfo.save();
+        plugin.getLogger().info("Migrated legacy player challenge progress for " + playerInfo.getPlayerName() + ".");
+        return true;
+    }
+
+    private boolean importLegacyFileProgress(@NotNull IslandKey islandKey, @NotNull Map<ChallengeKey, ChallengeCompletion> current) {
+        Path islandFile = legacyStorageDir.resolve(islandKey.value() + ".yml");
+        if (Files.exists(islandFile)) {
+            Map<ChallengeKey, ChallengeCompletion> imported = loadLegacyFile(islandFile.toFile());
+            current.putAll(imported);
+            backupLegacyFile(islandFile);
+            plugin.getLogger().info("Migrated legacy island challenge progress for " + islandKey.value() + ".");
+            return true;
+        }
+
+        IslandInfo islandInfo = plugin.getIslandInfo(islandKey.value());
+        if (islandInfo != null && islandInfo.getLeaderUniqueId() != null) {
+            Path leaderFile = legacyStorageDir.resolve(islandInfo.getLeaderUniqueId() + ".yml");
+            if (Files.exists(leaderFile)) {
+                Map<ChallengeKey, ChallengeCompletion> imported = loadLegacyFile(leaderFile.toFile());
+                current.putAll(imported);
+                backupLegacyFile(leaderFile);
+                plugin.getLogger().info("Migrated legacy leader challenge progress for " + islandKey.value() + ".");
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private @NotNull Map<ChallengeKey, ChallengeCompletion> loadLegacyFile(@NotNull File configFile) {
+        FileConfiguration fileConfiguration = YamlConfiguration.loadConfiguration(configFile);
+        if (fileConfiguration.getRoot() == null) {
+            return Collections.emptyMap();
+        }
+        return loadFromConfiguration(fileConfiguration.getRoot());
+    }
+
+    private void backupLegacyFile(@NotNull Path source) {
+        try {
+            Path backupDir = legacyStorageDir.resolve("legacy-backup");
+            Files.createDirectories(backupDir);
+            Path target = backupDir.resolve(source.getFileName());
+            int suffix = 1;
+            while (Files.exists(target)) {
+                target = backupDir.resolve(source.getFileName().toString().replace(".yml", "-" + suffix + ".yml"));
+                suffix++;
+            }
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.WARNING, "Unable to back up legacy challenge progress file " + source, e);
+        }
     }
 }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogic.java
@@ -60,11 +60,7 @@ public class ChallengeCompletionLogic {
         if (!Files.exists(legacyStorageDir)) {
             legacyStorageDir.toFile().mkdirs();
         }
-        Map<IslandKey, Map<ChallengeKey, ChallengeCompletion>> migratedProgress =
-            new ChallengeProgressMigration(plugin, repository).migrateLegacyDataEagerly();
-        for (Map.Entry<IslandKey, Map<ChallengeKey, ChallengeCompletion>> entry : migratedProgress.entrySet()) {
-            completionCache.put(entry.getKey(), entry.getValue());
-        }
+        new ChallengeProgressMigration(plugin, repository).migrateLegacyDataEagerly();
     }
 
     private Map<ChallengeKey, ChallengeCompletion> loadOrPopulateProgress(IslandKey islandKey) {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java
@@ -123,7 +123,7 @@ public class ChallengeLogic implements Listener {
         this.defaults = ChallengeFactory.createDefaults(config.getRoot());
         ranks = challengeFactory.createRankMap(config.getConfigurationSection("ranks"), defaults);
         rebuildIndex();
-        completionLogic = new ChallengeCompletionLogic(plugin, runtimeConfigs, config, challengeProgressRepository);
+        completionLogic = new ChallengeCompletionLogic(this, plugin, runtimeConfigs, config, challengeProgressRepository);
         String displayItemForLocked = config.getString("lockedDisplayItem", null);
         if (displayItemForLocked != null) {
             lockedItem = gameObjects.itemStack(displayItemForLocked).create();

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java
@@ -111,7 +111,8 @@ public class ChallengeLogic implements Listener {
         @NotNull PerkLogic perkLogic,
         @NotNull HookManager hookManager,
         @NotNull GameObjectFactory gameObjects,
-        @NotNull ChallengeFactory challengeFactory
+        @NotNull ChallengeFactory challengeFactory,
+        @NotNull ChallengeProgressRepository challengeProgressRepository
     ) {
         this.logger = logger;
         this.perkLogic = perkLogic;
@@ -122,7 +123,7 @@ public class ChallengeLogic implements Listener {
         this.defaults = ChallengeFactory.createDefaults(config.getRoot());
         ranks = challengeFactory.createRankMap(config.getConfigurationSection("ranks"), defaults);
         rebuildIndex();
-        completionLogic = new ChallengeCompletionLogic(plugin, runtimeConfigs, config);
+        completionLogic = new ChallengeCompletionLogic(plugin, runtimeConfigs, config, challengeProgressRepository);
         String displayItemForLocked = config.getString("lockedDisplayItem", null);
         if (displayItemForLocked != null) {
             lockedItem = gameObjects.itemStack(displayItemForLocked).create();

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressMigration.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressMigration.java
@@ -6,11 +6,12 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.jetbrains.annotations.NotNull;
 import us.talabrek.ultimateskyblock.island.IslandKey;
 import us.talabrek.ultimateskyblock.uSkyBlock;
+import us.talabrek.ultimateskyblock.util.BackupFileUtil;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
@@ -256,16 +257,12 @@ final class ChallengeProgressMigration {
 
     private void backupLegacyFile(@NotNull Path source) {
         try {
-            Path backupDir = legacyStorageDir.resolve("legacy-backup");
-            Files.createDirectories(backupDir);
-            Path target = backupDir.resolve(source.getFileName());
-            int suffix = 1;
-            while (Files.exists(target)) {
-                target = backupDir.resolve(source.getFileName().toString().replace(".yml", "-" + suffix + ".yml"));
-                suffix++;
-            }
-            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
-        } catch (Exception e) {
+            BackupFileUtil.moveToBackup(
+                plugin.getDataFolder().toPath(),
+                source,
+                "completion/" + source.getFileName()
+            );
+        } catch (IOException e) {
             plugin.getLogger().log(Level.WARNING, "Unable to back up legacy challenge progress file " + source, e);
         }
     }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressMigration.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressMigration.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import java.util.logging.Level;
 
 final class ChallengeProgressMigration {
+    private static final String LEGACY_IMPORT_COMPLETED_KEY = "legacy_yaml_import_completed";
     private record LegacyPlayerProgress(Path path, YamlConfiguration config) {}
 
     private final uSkyBlock plugin;
@@ -37,7 +38,11 @@ final class ChallengeProgressMigration {
         this.islandStorageDir = plugin.getDataFolder().toPath().resolve("islands");
     }
 
-    @NotNull Map<IslandKey, Map<ChallengeKey, ChallengeCompletion>> migrateLegacyDataEagerly() {
+    void migrateLegacyDataEagerly() {
+        if (repository.getMetadata(LEGACY_IMPORT_COMPLETED_KEY).isPresent()) {
+            return;
+        }
+
         Map<IslandKey, Map<ChallengeKey, ChallengeCompletion>> migratedProgress = new HashMap<>();
         Map<IslandKey, List<Path>> migratedFiles = new HashMap<>();
         Map<IslandKey, List<LegacyPlayerProgress>> migratedPlayerConfigs = new HashMap<>();
@@ -45,18 +50,12 @@ final class ChallengeProgressMigration {
         migrateLegacyCompletionFiles(migratedProgress, migratedFiles);
         migrateLegacyPlayerFiles(migratedProgress, migratedPlayerConfigs);
 
-        if (migratedProgress.isEmpty()) {
-            return Map.of();
-        }
-
-        Map<IslandKey, Map<ChallengeKey, ChallengeCompletion>> migratedCacheEntries = new HashMap<>();
         int migratedIslands = 0;
         for (Map.Entry<IslandKey, Map<ChallengeKey, ChallengeCompletion>> entry : migratedProgress.entrySet()) {
             IslandKey islandKey = entry.getKey();
             Map<ChallengeKey, ChallengeCompletion> merged = loadOrPopulateProgress(islandKey);
             mergeProgress(merged, entry.getValue());
             repository.replace(islandKey, merged);
-            migratedCacheEntries.put(islandKey, merged);
 
             for (Path file : migratedFiles.getOrDefault(islandKey, List.of())) {
                 backupLegacyFile(file);
@@ -71,8 +70,8 @@ final class ChallengeProgressMigration {
             }
             migratedIslands++;
         }
+        repository.putMetadata(LEGACY_IMPORT_COMPLETED_KEY, "true");
         plugin.getLogger().info("Migrated legacy challenge progress for " + migratedIslands + " island(s) into SQLite storage.");
-        return migratedCacheEntries;
     }
 
     private @NotNull Map<ChallengeKey, ChallengeCompletion> loadOrPopulateProgress(IslandKey islandKey) {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressMigration.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressMigration.java
@@ -70,6 +70,7 @@ final class ChallengeProgressMigration {
             }
             migratedIslands++;
         }
+        cleanupLegacyCompletionDir();
         repository.putMetadata(LEGACY_IMPORT_COMPLETED_KEY, "true");
         plugin.getLogger().info("Migrated legacy challenge progress for " + migratedIslands + " island(s) into SQLite storage.");
     }
@@ -263,6 +264,19 @@ final class ChallengeProgressMigration {
             );
         } catch (IOException e) {
             plugin.getLogger().log(Level.WARNING, "Unable to back up legacy challenge progress file " + source, e);
+        }
+    }
+
+    private void cleanupLegacyCompletionDir() {
+        if (!Files.isDirectory(legacyStorageDir)) {
+            return;
+        }
+        try (var files = Files.list(legacyStorageDir)) {
+            if (files.findAny().isEmpty()) {
+                Files.delete(legacyStorageDir);
+            }
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.FINE, "Unable to clean up legacy completion directory " + legacyStorageDir, e);
         }
     }
 }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressMigration.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressMigration.java
@@ -25,13 +25,19 @@ final class ChallengeProgressMigration {
     private record LegacyPlayerProgress(Path path, YamlConfiguration config) {}
 
     private final uSkyBlock plugin;
+    private final ChallengeLogic challengeLogic;
     private final ChallengeProgressRepository repository;
     private final Path legacyStorageDir;
     private final Path playerStorageDir;
     private final Path islandStorageDir;
 
-    ChallengeProgressMigration(@NotNull uSkyBlock plugin, @NotNull ChallengeProgressRepository repository) {
+    ChallengeProgressMigration(
+        @NotNull uSkyBlock plugin,
+        @NotNull ChallengeLogic challengeLogic,
+        @NotNull ChallengeProgressRepository repository
+    ) {
         this.plugin = plugin;
+        this.challengeLogic = challengeLogic;
         this.repository = repository;
         this.legacyStorageDir = plugin.getDataFolder().toPath().resolve("completion");
         this.playerStorageDir = plugin.getDataFolder().toPath().resolve("players");
@@ -77,7 +83,7 @@ final class ChallengeProgressMigration {
 
     private @NotNull Map<ChallengeKey, ChallengeCompletion> loadOrPopulateProgress(IslandKey islandKey) {
         Map<ChallengeKey, ChallengeCompletion> challengeMap = new HashMap<>();
-        plugin.getChallengeLogic().populateChallenges(challengeMap);
+        challengeLogic.populateChallenges(challengeMap);
         challengeMap.putAll(repository.load(islandKey));
         return challengeMap;
     }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressMigration.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressMigration.java
@@ -1,0 +1,272 @@
+package us.talabrek.ultimateskyblock.challenge;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.jetbrains.annotations.NotNull;
+import us.talabrek.ultimateskyblock.island.IslandKey;
+import us.talabrek.ultimateskyblock.uSkyBlock;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Level;
+
+final class ChallengeProgressMigration {
+    private record LegacyPlayerProgress(Path path, YamlConfiguration config) {}
+
+    private final uSkyBlock plugin;
+    private final ChallengeProgressRepository repository;
+    private final Path legacyStorageDir;
+    private final Path playerStorageDir;
+    private final Path islandStorageDir;
+
+    ChallengeProgressMigration(@NotNull uSkyBlock plugin, @NotNull ChallengeProgressRepository repository) {
+        this.plugin = plugin;
+        this.repository = repository;
+        this.legacyStorageDir = plugin.getDataFolder().toPath().resolve("completion");
+        this.playerStorageDir = plugin.getDataFolder().toPath().resolve("players");
+        this.islandStorageDir = plugin.getDataFolder().toPath().resolve("islands");
+    }
+
+    @NotNull Map<IslandKey, Map<ChallengeKey, ChallengeCompletion>> migrateLegacyDataEagerly() {
+        Map<IslandKey, Map<ChallengeKey, ChallengeCompletion>> migratedProgress = new HashMap<>();
+        Map<IslandKey, List<Path>> migratedFiles = new HashMap<>();
+        Map<IslandKey, List<LegacyPlayerProgress>> migratedPlayerConfigs = new HashMap<>();
+
+        migrateLegacyCompletionFiles(migratedProgress, migratedFiles);
+        migrateLegacyPlayerFiles(migratedProgress, migratedPlayerConfigs);
+
+        if (migratedProgress.isEmpty()) {
+            return Map.of();
+        }
+
+        Map<IslandKey, Map<ChallengeKey, ChallengeCompletion>> migratedCacheEntries = new HashMap<>();
+        int migratedIslands = 0;
+        for (Map.Entry<IslandKey, Map<ChallengeKey, ChallengeCompletion>> entry : migratedProgress.entrySet()) {
+            IslandKey islandKey = entry.getKey();
+            Map<ChallengeKey, ChallengeCompletion> merged = loadOrPopulateProgress(islandKey);
+            mergeProgress(merged, entry.getValue());
+            repository.replace(islandKey, merged);
+            migratedCacheEntries.put(islandKey, merged);
+
+            for (Path file : migratedFiles.getOrDefault(islandKey, List.of())) {
+                backupLegacyFile(file);
+            }
+            for (LegacyPlayerProgress playerProgress : migratedPlayerConfigs.getOrDefault(islandKey, List.of())) {
+                playerProgress.config().set("player.challenges", null);
+                try {
+                    playerProgress.config().save(playerProgress.path().toFile());
+                } catch (Exception e) {
+                    plugin.getLogger().log(Level.WARNING, "Unable to clear migrated legacy player challenge progress from " + playerProgress.path(), e);
+                }
+            }
+            migratedIslands++;
+        }
+        plugin.getLogger().info("Migrated legacy challenge progress for " + migratedIslands + " island(s) into SQLite storage.");
+        return migratedCacheEntries;
+    }
+
+    private @NotNull Map<ChallengeKey, ChallengeCompletion> loadOrPopulateProgress(IslandKey islandKey) {
+        Map<ChallengeKey, ChallengeCompletion> challengeMap = new HashMap<>();
+        plugin.getChallengeLogic().populateChallenges(challengeMap);
+        challengeMap.putAll(repository.load(islandKey));
+        return challengeMap;
+    }
+
+    private void migrateLegacyCompletionFiles(
+        @NotNull Map<IslandKey, Map<ChallengeKey, ChallengeCompletion>> migratedProgress,
+        @NotNull Map<IslandKey, List<Path>> migratedFiles
+    ) {
+        if (!Files.isDirectory(legacyStorageDir)) {
+            return;
+        }
+        Map<UUID, IslandKey> islandsByLeader = loadIslandsByLeaderUuid();
+        try (var files = Files.list(legacyStorageDir)) {
+            files.filter(path -> Files.isRegularFile(path) && path.getFileName().toString().endsWith(".yml"))
+                .forEach(path -> {
+                    IslandKey islandKey = resolveLegacyCompletionOwner(path, islandsByLeader);
+                    if (islandKey == null) {
+                        plugin.getLogger().warning("Unable to resolve legacy challenge progress owner for " + path.getFileName() + ". Leaving file in place.");
+                        return;
+                    }
+                    mergeProgress(
+                        migratedProgress.computeIfAbsent(islandKey, ignored -> new HashMap<>()),
+                        loadLegacyFile(path.toFile())
+                    );
+                    migratedFiles.computeIfAbsent(islandKey, ignored -> new java.util.ArrayList<>()).add(path);
+                });
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.WARNING, "Unable to scan legacy challenge progress directory " + legacyStorageDir, e);
+        }
+    }
+
+    private void migrateLegacyPlayerFiles(
+        @NotNull Map<IslandKey, Map<ChallengeKey, ChallengeCompletion>> migratedProgress,
+        @NotNull Map<IslandKey, List<LegacyPlayerProgress>> migratedPlayerConfigs
+    ) {
+        if (!Files.isDirectory(playerStorageDir)) {
+            return;
+        }
+        try (var files = Files.list(playerStorageDir)) {
+            files.filter(path -> Files.isRegularFile(path) && path.getFileName().toString().endsWith(".yml"))
+                .forEach(path -> {
+                    YamlConfiguration config = YamlConfiguration.loadConfiguration(path.toFile());
+                    ConfigurationSection challengeSection = config.getConfigurationSection("player.challenges");
+                    if (challengeSection == null || challengeSection.getKeys(false).isEmpty()) {
+                        return;
+                    }
+                    IslandKey islandKey = resolvePlayerIslandKey(config);
+                    if (islandKey == null) {
+                        plugin.getLogger().warning("Unable to resolve island owner for legacy player challenge progress in " + path.getFileName() + ". Leaving data in place.");
+                        return;
+                    }
+                    mergeProgress(
+                        migratedProgress.computeIfAbsent(islandKey, ignored -> new HashMap<>()),
+                        loadFromConfiguration(challengeSection)
+                    );
+                    migratedPlayerConfigs.computeIfAbsent(islandKey, ignored -> new java.util.ArrayList<>())
+                        .add(new LegacyPlayerProgress(path, config));
+                });
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.WARNING, "Unable to scan player data directory " + playerStorageDir + " for legacy challenge progress", e);
+        }
+    }
+
+    private @NotNull Map<UUID, IslandKey> loadIslandsByLeaderUuid() {
+        Map<UUID, IslandKey> islandsByLeader = new HashMap<>();
+        if (!Files.isDirectory(islandStorageDir)) {
+            return islandsByLeader;
+        }
+        try (var files = Files.list(islandStorageDir)) {
+            files.filter(path -> Files.isRegularFile(path) && path.getFileName().toString().endsWith(".yml"))
+                .forEach(path -> {
+                    YamlConfiguration config = YamlConfiguration.loadConfiguration(path.toFile());
+                    String leaderUuid = config.getString("party.leader-uuid", null);
+                    if (leaderUuid == null || leaderUuid.isBlank()) {
+                        return;
+                    }
+                    try {
+                        String fileName = path.getFileName().toString();
+                        String islandName = fileName.substring(0, fileName.length() - 4);
+                        islandsByLeader.put(UUID.fromString(leaderUuid), IslandKey.fromIslandName(islandName));
+                    } catch (IllegalArgumentException ignored) {
+                        // Ignore invalid leader UUIDs or non-island-named files.
+                    }
+                });
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.WARNING, "Unable to scan island data directory " + islandStorageDir, e);
+        }
+        return islandsByLeader;
+    }
+
+    private IslandKey resolveLegacyCompletionOwner(@NotNull Path legacyFile, @NotNull Map<UUID, IslandKey> islandsByLeader) {
+        String fileName = legacyFile.getFileName().toString();
+        String basename = fileName.substring(0, fileName.length() - 4);
+        try {
+            return IslandKey.fromIslandName(basename);
+        } catch (IllegalArgumentException ignored) {
+            // fall through
+        }
+        try {
+            return islandsByLeader.get(UUID.fromString(basename));
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private IslandKey resolvePlayerIslandKey(@NotNull YamlConfiguration config) {
+        int islandY = config.getInt("player.islandY", 0);
+        if (islandY == 0) {
+            return null;
+        }
+        int islandX = config.getInt("player.islandX", 0);
+        int islandZ = config.getInt("player.islandZ", 0);
+        try {
+            return IslandKey.fromIslandName(islandX + "," + islandZ);
+        } catch (IllegalArgumentException ignored) {
+            return null;
+        }
+    }
+
+    private @NotNull Map<ChallengeKey, ChallengeCompletion> loadLegacyFile(@NotNull File configFile) {
+        FileConfiguration fileConfiguration = YamlConfiguration.loadConfiguration(configFile);
+        if (fileConfiguration.getRoot() == null) {
+            return Collections.emptyMap();
+        }
+        return loadFromConfiguration(fileConfiguration.getRoot());
+    }
+
+    private @NotNull Map<ChallengeKey, ChallengeCompletion> loadFromConfiguration(ConfigurationSection root) {
+        Map<ChallengeKey, ChallengeCompletion> challengeMap = new HashMap<>();
+        if (root != null) {
+            for (String challengeName : root.getKeys(false)) {
+                long firstCompleted = root.getLong(challengeName + ".firstCompleted", 0);
+                Instant firstCompletedDuration = firstCompleted > 0 ? Instant.ofEpochMilli(firstCompleted) : null;
+                ChallengeKey challengeId = ChallengeKey.of(challengeName);
+                challengeMap.put(challengeId, new ChallengeCompletion(
+                    challengeId,
+                    firstCompletedDuration,
+                    root.getInt(challengeName + ".timesCompleted", 0),
+                    root.getInt(challengeName + ".timesCompletedSinceTimer", 0)
+                ));
+            }
+        }
+        return challengeMap;
+    }
+
+    private void mergeProgress(@NotNull Map<ChallengeKey, ChallengeCompletion> target, @NotNull Map<ChallengeKey, ChallengeCompletion> incoming) {
+        for (Map.Entry<ChallengeKey, ChallengeCompletion> entry : incoming.entrySet()) {
+            ChallengeCompletion existing = target.get(entry.getKey());
+            if (existing == null) {
+                target.put(entry.getKey(), entry.getValue());
+                continue;
+            }
+            target.put(entry.getKey(), mergeCompletion(entry.getKey(), existing, entry.getValue()));
+        }
+    }
+
+    private ChallengeCompletion mergeCompletion(
+        @NotNull ChallengeKey challengeKey,
+        @NotNull ChallengeCompletion left,
+        @NotNull ChallengeCompletion right
+    ) {
+        Instant cooldownUntil = maxInstant(left.cooldownUntil(), right.cooldownUntil());
+        int timesCompleted = Math.max(left.getTimesCompleted(), right.getTimesCompleted());
+        int timesCompletedInCooldown = Math.max(left.getTimesCompletedInCooldown(), right.getTimesCompletedInCooldown());
+        return new ChallengeCompletion(challengeKey, cooldownUntil, timesCompleted, timesCompletedInCooldown);
+    }
+
+    private Instant maxInstant(Instant left, Instant right) {
+        if (left == null) {
+            return right;
+        }
+        if (right == null) {
+            return left;
+        }
+        return left.isAfter(right) ? left : right;
+    }
+
+    private void backupLegacyFile(@NotNull Path source) {
+        try {
+            Path backupDir = legacyStorageDir.resolve("legacy-backup");
+            Files.createDirectories(backupDir);
+            Path target = backupDir.resolve(source.getFileName());
+            int suffix = 1;
+            while (Files.exists(target)) {
+                target = backupDir.resolve(source.getFileName().toString().replace(".yml", "-" + suffix + ".yml"));
+                suffix++;
+            }
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            plugin.getLogger().log(Level.WARNING, "Unable to back up legacy challenge progress file " + source, e);
+        }
+    }
+}

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressRepository.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressRepository.java
@@ -1,0 +1,21 @@
+package us.talabrek.ultimateskyblock.challenge;
+
+import org.jetbrains.annotations.NotNull;
+import us.talabrek.ultimateskyblock.island.IslandKey;
+
+import java.util.Map;
+
+public interface ChallengeProgressRepository extends AutoCloseable {
+    @NotNull Map<ChallengeKey, ChallengeCompletion> load(@NotNull IslandKey islandKey);
+
+    void replace(@NotNull IslandKey islandKey, @NotNull Map<ChallengeKey, ChallengeCompletion> progress);
+
+    boolean hasProgress(@NotNull IslandKey islandKey);
+
+    void shutdown();
+
+    @Override
+    default void close() {
+        shutdown();
+    }
+}

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressRepository.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressRepository.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import us.talabrek.ultimateskyblock.island.IslandKey;
 
 import java.util.Map;
+import java.util.Optional;
 
 public interface ChallengeProgressRepository extends AutoCloseable {
     @NotNull Map<ChallengeKey, ChallengeCompletion> load(@NotNull IslandKey islandKey);
@@ -11,6 +12,10 @@ public interface ChallengeProgressRepository extends AutoCloseable {
     void replace(@NotNull IslandKey islandKey, @NotNull Map<ChallengeKey, ChallengeCompletion> progress);
 
     boolean hasProgress(@NotNull IslandKey islandKey);
+
+    @NotNull Optional<String> getMetadata(@NotNull String key);
+
+    void putMetadata(@NotNull String key, @NotNull String value);
 
     void shutdown();
 

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/SqliteChallengeProgressRepository.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/SqliteChallengeProgressRepository.java
@@ -13,6 +13,7 @@ import java.sql.Statement;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -127,6 +128,37 @@ public class SqliteChallengeProgressRepository implements ChallengeProgressRepos
     }
 
     @Override
+    public @NotNull Optional<String> getMetadata(@NotNull String key) {
+        String sql = "SELECT value FROM challenge_progress_meta WHERE key = ?";
+        try (Connection connection = openConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, key);
+            try (ResultSet rs = statement.executeQuery()) {
+                return rs.next() ? Optional.ofNullable(rs.getString("value")) : Optional.empty();
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Unable to query challenge progress metadata for key " + key, e);
+        }
+    }
+
+    @Override
+    public void putMetadata(@NotNull String key, @NotNull String value) {
+        String sql = """
+            INSERT INTO challenge_progress_meta(key, value)
+            VALUES (?, ?)
+            ON CONFLICT(key) DO UPDATE SET value=excluded.value
+            """;
+        try (Connection connection = openConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, key);
+            statement.setString(2, value);
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException("Unable to store challenge progress metadata for key " + key, e);
+        }
+    }
+
+    @Override
     public void shutdown() {
         // No-op. Connections are short-lived per operation.
     }
@@ -172,15 +204,7 @@ public class SqliteChallengeProgressRepository implements ChallengeProgressRepos
                 """);
         }
 
-        try (Connection connection = openConnection();
-             PreparedStatement statement = connection.prepareStatement("""
-                 INSERT INTO challenge_progress_meta(key, value)
-                 VALUES ('schema_version', ?)
-                ON CONFLICT(key) DO UPDATE SET value=excluded.value
-                 """)) {
-            statement.setString(1, SCHEMA_VERSION);
-            statement.executeUpdate();
-        }
+        putMetadata("schema_version", SCHEMA_VERSION);
     }
 
     private static boolean isDefault(@NotNull ChallengeCompletion completion) {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/SqliteChallengeProgressRepository.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/SqliteChallengeProgressRepository.java
@@ -1,0 +1,181 @@
+package us.talabrek.ultimateskyblock.challenge;
+
+import org.jetbrains.annotations.NotNull;
+import us.talabrek.ultimateskyblock.island.IslandKey;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class SqliteChallengeProgressRepository implements ChallengeProgressRepository {
+    private static final String SCHEMA_VERSION = "1";
+
+    private final Logger logger;
+    private final String jdbcUrl;
+
+    public SqliteChallengeProgressRepository(@NotNull Path dbPath, @NotNull Logger logger) {
+        this.logger = logger;
+        this.jdbcUrl = "jdbc:sqlite:" + dbPath.toAbsolutePath();
+        try {
+            java.nio.file.Files.createDirectories(dbPath.toAbsolutePath().getParent());
+            initialize();
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to initialize challenge progress database at " + dbPath, e);
+        }
+    }
+
+    @Override
+    public @NotNull Map<ChallengeKey, ChallengeCompletion> load(@NotNull IslandKey islandKey) {
+        Map<ChallengeKey, ChallengeCompletion> progress = new HashMap<>();
+        String sql = """
+            SELECT challenge_id, cooldown_until_ms, times_completed, times_completed_in_window
+            FROM challenge_progress
+            WHERE island_key = ?
+            """;
+        try (Connection connection = openConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, islandKey.value());
+            try (ResultSet rs = statement.executeQuery()) {
+                while (rs.next()) {
+                    Long cooldownUntil = rs.getObject("cooldown_until_ms", Long.class);
+                    progress.put(
+                        ChallengeKey.of(rs.getString("challenge_id")),
+                        new ChallengeCompletion(
+                            ChallengeKey.of(rs.getString("challenge_id")),
+                            cooldownUntil != null ? Instant.ofEpochMilli(cooldownUntil) : null,
+                            rs.getInt("times_completed"),
+                            rs.getInt("times_completed_in_window")
+                        )
+                    );
+                }
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Unable to load challenge progress for " + islandKey.value(), e);
+        }
+        return progress;
+    }
+
+    @Override
+    public void replace(@NotNull IslandKey islandKey, @NotNull Map<ChallengeKey, ChallengeCompletion> progress) {
+        String deleteSql = "DELETE FROM challenge_progress WHERE island_key = ?";
+        String insertSql = """
+            INSERT INTO challenge_progress (
+                island_key, challenge_id, cooldown_until_ms, times_completed, times_completed_in_window, updated_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """;
+        try (Connection connection = openConnection()) {
+            connection.setAutoCommit(false);
+            try (PreparedStatement delete = connection.prepareStatement(deleteSql)) {
+                delete.setString(1, islandKey.value());
+                delete.executeUpdate();
+            }
+            try (PreparedStatement insert = connection.prepareStatement(insertSql)) {
+                long updatedAt = System.currentTimeMillis();
+                for (Map.Entry<ChallengeKey, ChallengeCompletion> entry : progress.entrySet()) {
+                    ChallengeCompletion completion = entry.getValue();
+                    if (isDefault(completion)) {
+                        continue;
+                    }
+                    insert.setString(1, islandKey.value());
+                    insert.setString(2, entry.getKey().id());
+                    if (completion.cooldownUntil() != null) {
+                        insert.setLong(3, completion.cooldownUntil().toEpochMilli());
+                    } else {
+                        insert.setObject(3, null);
+                    }
+                    insert.setInt(4, completion.getTimesCompleted());
+                    insert.setInt(5, completion.getTimesCompletedInCooldown());
+                    insert.setLong(6, updatedAt);
+                    insert.addBatch();
+                }
+                insert.executeBatch();
+            }
+            connection.commit();
+        } catch (SQLException e) {
+            throw new IllegalStateException("Unable to store challenge progress for " + islandKey.value(), e);
+        }
+    }
+
+    @Override
+    public boolean hasProgress(@NotNull IslandKey islandKey) {
+        String sql = "SELECT 1 FROM challenge_progress WHERE island_key = ? LIMIT 1";
+        try (Connection connection = openConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, islandKey.value());
+            try (ResultSet rs = statement.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Unable to query challenge progress for " + islandKey.value(), e);
+        }
+    }
+
+    @Override
+    public void shutdown() {
+        // No-op. Connections are short-lived per operation.
+    }
+
+    private @NotNull Connection openConnection() throws SQLException {
+        Connection connection = DriverManager.getConnection(jdbcUrl);
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("PRAGMA foreign_keys = ON");
+        } catch (SQLException e) {
+            logger.log(Level.FINE, "Unable to enable SQLite foreign keys", e);
+        }
+        return connection;
+    }
+
+    private void initialize() throws SQLException {
+        try (Connection connection = openConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute("""
+                CREATE TABLE IF NOT EXISTS challenge_progress (
+                    island_key TEXT NOT NULL,
+                    challenge_id TEXT NOT NULL,
+                    cooldown_until_ms BIGINT NULL,
+                    times_completed INTEGER NOT NULL,
+                    times_completed_in_window INTEGER NOT NULL,
+                    updated_at_ms BIGINT NOT NULL,
+                    PRIMARY KEY (island_key, challenge_id),
+                    CHECK (times_completed >= 0),
+                    CHECK (times_completed_in_window >= 0)
+                )
+                """);
+            statement.execute("""
+                CREATE INDEX IF NOT EXISTS idx_challenge_progress_island
+                ON challenge_progress (island_key)
+                """);
+            statement.execute("""
+                CREATE TABLE IF NOT EXISTS challenge_progress_meta (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                )
+                """);
+        }
+
+        try (Connection connection = openConnection();
+             PreparedStatement statement = connection.prepareStatement("""
+                 INSERT INTO challenge_progress_meta(key, value)
+                 VALUES ('schema_version', ?)
+                 ON CONFLICT(key) DO UPDATE SET value=excluded.value
+                 """)) {
+            statement.setString(1, SCHEMA_VERSION);
+            statement.executeUpdate();
+        }
+    }
+
+    private static boolean isDefault(@NotNull ChallengeCompletion completion) {
+        return completion.cooldownUntil() == null
+            && completion.getTimesCompleted() == 0
+            && completion.getTimesCompletedInCooldown() == 0;
+    }
+}

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/SqliteChallengeProgressRepository.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/SqliteChallengeProgressRepository.java
@@ -18,6 +18,7 @@ import java.util.logging.Logger;
 
 public class SqliteChallengeProgressRepository implements ChallengeProgressRepository {
     private static final String SCHEMA_VERSION = "1";
+    private static final int BUSY_TIMEOUT_MS = 5_000;
 
     private final Logger logger;
     private final String jdbcUrl;
@@ -74,33 +75,39 @@ public class SqliteChallengeProgressRepository implements ChallengeProgressRepos
             """;
         try (Connection connection = openConnection()) {
             connection.setAutoCommit(false);
-            try (PreparedStatement delete = connection.prepareStatement(deleteSql)) {
-                delete.setString(1, islandKey.value());
-                delete.executeUpdate();
-            }
-            try (PreparedStatement insert = connection.prepareStatement(insertSql)) {
-                long updatedAt = System.currentTimeMillis();
-                for (Map.Entry<ChallengeKey, ChallengeCompletion> entry : progress.entrySet()) {
-                    ChallengeCompletion completion = entry.getValue();
-                    if (isDefault(completion)) {
-                        continue;
-                    }
-                    insert.setString(1, islandKey.value());
-                    insert.setString(2, entry.getKey().id());
-                    if (completion.cooldownUntil() != null) {
-                        insert.setLong(3, completion.cooldownUntil().toEpochMilli());
-                    } else {
-                        insert.setObject(3, null);
-                    }
-                    insert.setInt(4, completion.getTimesCompleted());
-                    insert.setInt(5, completion.getTimesCompletedInCooldown());
-                    insert.setLong(6, updatedAt);
-                    insert.addBatch();
+            try {
+                try (PreparedStatement delete = connection.prepareStatement(deleteSql)) {
+                    delete.setString(1, islandKey.value());
+                    delete.executeUpdate();
                 }
-                insert.executeBatch();
+                try (PreparedStatement insert = connection.prepareStatement(insertSql)) {
+                    long updatedAt = System.currentTimeMillis();
+                    for (Map.Entry<ChallengeKey, ChallengeCompletion> entry : progress.entrySet()) {
+                        ChallengeCompletion completion = entry.getValue();
+                        if (isDefault(completion)) {
+                            continue;
+                        }
+                        insert.setString(1, islandKey.value());
+                        insert.setString(2, entry.getKey().id());
+                        if (completion.cooldownUntil() != null) {
+                            insert.setLong(3, completion.cooldownUntil().toEpochMilli());
+                        } else {
+                            insert.setObject(3, null);
+                        }
+                        insert.setInt(4, completion.getTimesCompleted());
+                        insert.setInt(5, completion.getTimesCompletedInCooldown());
+                        insert.setLong(6, updatedAt);
+                        insert.addBatch();
+                    }
+                    insert.executeBatch();
+                }
+                connection.commit();
+            } catch (SQLException e) {
+                connection.rollback();
+                throw e;
             }
-            connection.commit();
         } catch (SQLException e) {
+            logger.log(Level.FINE, "Unable to store challenge progress for " + islandKey.value(), e);
             throw new IllegalStateException("Unable to store challenge progress for " + islandKey.value(), e);
         }
     }
@@ -127,9 +134,10 @@ public class SqliteChallengeProgressRepository implements ChallengeProgressRepos
     private @NotNull Connection openConnection() throws SQLException {
         Connection connection = DriverManager.getConnection(jdbcUrl);
         try (Statement statement = connection.createStatement()) {
+            statement.execute("PRAGMA busy_timeout = " + BUSY_TIMEOUT_MS);
             statement.execute("PRAGMA foreign_keys = ON");
         } catch (SQLException e) {
-            logger.log(Level.FINE, "Unable to enable SQLite foreign keys", e);
+            logger.log(Level.FINE, "Unable to apply SQLite connection pragmas", e);
         }
         return connection;
     }
@@ -137,6 +145,8 @@ public class SqliteChallengeProgressRepository implements ChallengeProgressRepos
     private void initialize() throws SQLException {
         try (Connection connection = openConnection();
              Statement statement = connection.createStatement()) {
+            statement.execute("PRAGMA journal_mode = WAL");
+            statement.execute("PRAGMA synchronous = NORMAL");
             statement.execute("""
                 CREATE TABLE IF NOT EXISTS challenge_progress (
                     island_key TEXT NOT NULL,
@@ -166,7 +176,7 @@ public class SqliteChallengeProgressRepository implements ChallengeProgressRepos
              PreparedStatement statement = connection.prepareStatement("""
                  INSERT INTO challenge_progress_meta(key, value)
                  VALUES ('schema_version', ?)
-                 ON CONFLICT(key) DO UPDATE SET value=excluded.value
+                ON CONFLICT(key) DO UPDATE SET value=excluded.value
                  """)) {
             statement.setString(1, SCHEMA_VERSION);
             statement.executeUpdate();

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/IslandKey.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/IslandKey.java
@@ -1,0 +1,27 @@
+package us.talabrek.ultimateskyblock.island;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Canonical storage identifier for an island.
+ */
+public record IslandKey(String value) {
+    private static final Pattern ISLAND_KEY_PATTERN = Pattern.compile("-?\\d+,-?\\d+");
+
+    public IslandKey {
+        value = Objects.requireNonNull(value, "value");
+        if (value.isBlank()) {
+            throw new IllegalArgumentException("Island key cannot be blank");
+        }
+        if (!ISLAND_KEY_PATTERN.matcher(value).matches()) {
+            throw new IllegalArgumentException("Invalid island key: " + value);
+        }
+    }
+
+    public static @NotNull IslandKey fromIslandName(@NotNull String islandName) {
+        return new IslandKey(islandName);
+    }
+}

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/util/BackupFileUtil.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/util/BackupFileUtil.java
@@ -33,6 +33,10 @@ public final class BackupFileUtil {
         Files.createDirectories(backupDir);
 
         Path candidate = backupDir.resolve(backupFileName);
+        Path candidateParent = candidate.getParent();
+        if (candidateParent != null) {
+            Files.createDirectories(candidateParent);
+        }
         if (!Files.exists(candidate)) {
             return candidate;
         }

--- a/uSkyBlock-Core/src/main/resources/plugin.yml
+++ b/uSkyBlock-Core/src/main/resources/plugin.yml
@@ -29,6 +29,7 @@ libraries:
   - org.apache.commons:commons-lang3:${apacheCommonsVersion}
   - org.apache.httpcomponents:httpclient:${apacheHttpVersion}
   - org.apache.maven:maven-artifact:${mavenArtifactVersion}
+  - org.xerial:sqlite-jdbc:${sqliteVersion}
 
 commands:
   challenges:

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
@@ -70,7 +70,7 @@ public class ChallengeCompletionLogicTest {
             assertEquals(3, loaded.get(challengeKey).getTimesCompleted());
             assertEquals(2, loaded.get(challengeKey).getTimesCompletedInCooldown());
             assertFalse(Files.exists(tempDir.resolve("completion/" + leaderUuid + ".yml")));
-            assertTrue(Files.exists(tempDir.resolve("completion/legacy-backup/" + leaderUuid + ".yml")));
+            assertTrue(Files.exists(tempDir.resolve("backup/completion/" + leaderUuid + ".yml")));
         }
     }
 

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
@@ -71,8 +71,31 @@ public class ChallengeCompletionLogicTest {
             assertEquals(3, loaded.get(challengeKey).getTimesCompleted());
             assertEquals(2, loaded.get(challengeKey).getTimesCompletedInCooldown());
             assertFalse(Files.exists(tempDir.resolve("completion/" + leaderUuid + ".yml")));
+            assertFalse(Files.exists(tempDir.resolve("completion")));
             assertTrue(Files.exists(tempDir.resolve("backup/completion/" + leaderUuid + ".yml")));
             assertEquals("true", repository.getMetadata("legacy_yaml_import_completed").orElseThrow());
+        }
+    }
+
+    @Test
+    public void keepsLegacyCompletionDirWhenOtherFilesRemain() throws Exception {
+        ChallengeKey challengeKey = ChallengeKey.of("cobblestonegenerator");
+        UUID leaderUuid = UUID.randomUUID();
+        long futureCooldown = System.currentTimeMillis() + 60_000L;
+        writeLegacyIsland(leaderUuid, "0,0");
+        writeLegacyCompletionFile(leaderUuid + ".yml", challengeKey, 3, 2, futureCooldown);
+        Path sentinel = tempDir.resolve("completion").resolve("README.txt");
+        Files.writeString(sentinel, "keep");
+
+        try (ChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
+            tempDir.resolve("data").resolve("challenge-progress.db"),
+            Logger.getAnonymousLogger()
+        )) {
+            new ChallengeCompletionLogic(plugin(challengeKey), runtimeConfigs(), challengeConfig("island"), repository);
+
+            assertTrue(Files.exists(tempDir.resolve("completion")));
+            assertTrue(Files.exists(sentinel));
+            assertTrue(Files.exists(tempDir.resolve("backup/completion/" + leaderUuid + ".yml")));
         }
     }
 

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
@@ -1,0 +1,118 @@
+package us.talabrek.ultimateskyblock.challenge;
+
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.Material;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfig;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigs;
+import us.talabrek.ultimateskyblock.gameobject.ItemStackSpec;
+import us.talabrek.ultimateskyblock.player.PlayerInfo;
+import us.talabrek.ultimateskyblock.uSkyBlock;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Locale;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ChallengeCompletionLogicTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void importsLegacyPlayerChallengesIntoRepository() {
+        ChallengeProgressRepository repository = mock(ChallengeProgressRepository.class);
+        when(repository.hasProgress(any())).thenReturn(false);
+        when(repository.load(any())).thenReturn(Map.of());
+
+        ChallengeLogic challengeLogic = mock(ChallengeLogic.class);
+        ChallengeKey challengeKey = ChallengeKey.of("cobblestonegenerator");
+        doAnswer(invocation -> {
+            @SuppressWarnings("unchecked")
+            Map<ChallengeKey, ChallengeCompletion> map = invocation.getArgument(0);
+            map.put(challengeKey, new ChallengeCompletion(challengeKey, null, 0, 0));
+            return null;
+        }).when(challengeLogic).populateChallenges(any());
+
+        uSkyBlock plugin = mock(uSkyBlock.class);
+        when(plugin.getChallengeLogic()).thenReturn(challengeLogic);
+        when(plugin.getLogger()).thenReturn(Logger.getAnonymousLogger());
+        when(plugin.getDataFolder()).thenReturn(tempDir.toFile());
+
+        RuntimeConfigs runtimeConfigs = mock(RuntimeConfigs.class);
+        when(runtimeConfigs.current()).thenReturn(runtimeConfig());
+
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("challengeSharing", "player");
+
+        ChallengeCompletionLogic logic = new ChallengeCompletionLogic(plugin, runtimeConfigs, config, repository);
+
+        PlayerInfo playerInfo = mock(PlayerInfo.class);
+        when(playerInfo.getHasIsland()).thenReturn(true);
+        when(playerInfo.locationForParty()).thenReturn("0,0");
+        when(playerInfo.getPlayerName()).thenReturn("TestPlayer");
+
+        YamlConfiguration playerConfig = new YamlConfiguration();
+        playerConfig.set("player.challenges.cobblestonegenerator.firstCompleted", 1000L);
+        playerConfig.set("player.challenges.cobblestonegenerator.timesCompleted", 2);
+        playerConfig.set("player.challenges.cobblestonegenerator.timesCompletedSinceTimer", 1);
+        when(playerInfo.getConfig()).thenReturn(playerConfig);
+
+        Map<ChallengeKey, ChallengeCompletion> loaded = logic.getChallenges(playerInfo);
+
+        assertEquals(2, loaded.get(challengeKey).getTimesCompleted());
+        assertEquals(1, loaded.get(challengeKey).getTimesCompletedInCooldown());
+        assertNull(playerConfig.get("player.challenges"));
+        verify(playerInfo).save();
+
+        ArgumentCaptor<Map<ChallengeKey, ChallengeCompletion>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(repository).replace(any(), captor.capture());
+        assertEquals(2, captor.getValue().get(challengeKey).getTimesCompleted());
+    }
+
+    private static RuntimeConfig runtimeConfig() {
+        ItemStackSpec tool = new ItemStackSpec(new org.bukkit.inventory.ItemStack(Material.STONE));
+        return new RuntimeConfig(
+            "en",
+            Locale.ENGLISH,
+            new RuntimeConfig.Init(Duration.ZERO),
+            new RuntimeConfig.General(4, "skyworld", Duration.ZERO, Duration.ZERO, Duration.ZERO, "plains", "nether_wastes", 64, Duration.ZERO),
+            new RuntimeConfig.Island(
+                128, 150, false, 128, 64, List.of(), true, Map.of(), true, true, true, "default",
+                Duration.ZERO, Duration.ZERO, false, Duration.ZERO, 0.5d, Duration.ZERO, true, 10, true, "",
+                new RuntimeConfig.SpawnLimits(true, 64, 50, 16, 5, 0), Map.of()
+            ),
+            new RuntimeConfig.Extras(false, true, true),
+            new RuntimeConfig.Protection(true, true, true, true, true, true, true, true, true, true, true, true, false, false, true, true, true, false, false, false, true),
+            new RuntimeConfig.Nether(false, 7, 75, "", new RuntimeConfig.Terraform(false, 0d, 0d, 0, Map.of(), Map.of()), new RuntimeConfig.SpawnChances(false, 0d, 0d, 0d)),
+            new RuntimeConfig.Restart(true, true, true, true, false, true, Duration.ZERO, List.of()),
+            new RuntimeConfig.Advanced(Duration.ZERO, false, 0d, true, "", "", "", "maximumSize=100", Duration.ZERO, Duration.ZERO, "", 4, Duration.ZERO, 0d, Duration.ZERO, null,
+                new RuntimeConfig.PlayerDb("bukkit", "", "", Duration.ZERO)),
+            new RuntimeConfig.Async(Duration.ZERO, 0L, Duration.ZERO),
+            new RuntimeConfig.AsyncWorldEdit(false, Duration.ZERO, Duration.ZERO),
+            new RuntimeConfig.Party(Duration.ZERO, "", List.of(), List.of(), Map.of()),
+            new RuntimeConfig.PluginUpdates(true, "RELEASE"),
+            new RuntimeConfig.Spawning(new RuntimeConfig.Guardians(false, 0, 0d), new RuntimeConfig.Phantoms(true, false)),
+            new RuntimeConfig.Placeholder(false, false, false),
+            new RuntimeConfig.ToolMenu(false, tool, List.of()),
+            new RuntimeConfig.Signs(true),
+            new RuntimeConfig.WorldGuard(true, true),
+            new RuntimeConfig.Importer(0.1d, Duration.ZERO),
+            Map.of(),
+            Map.of(),
+            Map.of(),
+            Map.of()
+        );
+    }
+}

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
@@ -37,7 +37,7 @@ public class ChallengeCompletionLogicTest {
         writeLegacyPlayerProgress("player-one.yml", 0, 64, 0, challengeKey, 2, 1, 1000L);
 
         try (ChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
-            tempDir.resolve("challenge-progress.db"),
+            tempDir.resolve("data").resolve("challenge-progress.db"),
             Logger.getAnonymousLogger()
         )) {
             ChallengeCompletionLogic logic = new ChallengeCompletionLogic(plugin(challengeKey), runtimeConfigs(), challengeConfig("player"), repository);
@@ -60,7 +60,7 @@ public class ChallengeCompletionLogicTest {
         writeLegacyCompletionFile(leaderUuid + ".yml", challengeKey, 3, 2, futureCooldown);
 
         try (ChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
-            tempDir.resolve("challenge-progress.db"),
+            tempDir.resolve("data").resolve("challenge-progress.db"),
             Logger.getAnonymousLogger()
         )) {
             ChallengeCompletionLogic logic = new ChallengeCompletionLogic(plugin(challengeKey), runtimeConfigs(), challengeConfig("island"), repository);

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
@@ -48,6 +48,7 @@ public class ChallengeCompletionLogicTest {
             assertEquals(1, loaded.get(challengeKey).getTimesCompletedInCooldown());
             assertNull(YamlConfiguration.loadConfiguration(tempDir.resolve("players/player-one.yml").toFile()).get("player.challenges"));
             assertTrue(repository.hasProgress(IslandKey.fromIslandName("0,0")));
+            assertEquals("true", repository.getMetadata("legacy_yaml_import_completed").orElseThrow());
         }
     }
 
@@ -71,6 +72,7 @@ public class ChallengeCompletionLogicTest {
             assertEquals(2, loaded.get(challengeKey).getTimesCompletedInCooldown());
             assertFalse(Files.exists(tempDir.resolve("completion/" + leaderUuid + ".yml")));
             assertTrue(Files.exists(tempDir.resolve("backup/completion/" + leaderUuid + ".yml")));
+            assertEquals("true", repository.getMetadata("legacy_yaml_import_completed").orElseThrow());
         }
     }
 

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
@@ -40,7 +40,8 @@ public class ChallengeCompletionLogicTest {
             tempDir.resolve("data").resolve("challenge-progress.db"),
             Logger.getAnonymousLogger()
         )) {
-            ChallengeCompletionLogic logic = new ChallengeCompletionLogic(plugin(challengeKey), runtimeConfigs(), challengeConfig("player"), repository);
+            ChallengeLogic challengeLogic = challengeLogic(challengeKey);
+            ChallengeCompletionLogic logic = new ChallengeCompletionLogic(challengeLogic, plugin(challengeLogic), runtimeConfigs(), challengeConfig("player"), repository);
 
             Map<ChallengeKey, ChallengeCompletion> loaded = logic.getIslandChallenges("0,0");
 
@@ -64,7 +65,8 @@ public class ChallengeCompletionLogicTest {
             tempDir.resolve("data").resolve("challenge-progress.db"),
             Logger.getAnonymousLogger()
         )) {
-            ChallengeCompletionLogic logic = new ChallengeCompletionLogic(plugin(challengeKey), runtimeConfigs(), challengeConfig("island"), repository);
+            ChallengeLogic challengeLogic = challengeLogic(challengeKey);
+            ChallengeCompletionLogic logic = new ChallengeCompletionLogic(challengeLogic, plugin(challengeLogic), runtimeConfigs(), challengeConfig("island"), repository);
 
             Map<ChallengeKey, ChallengeCompletion> loaded = logic.getIslandChallenges("0,0");
 
@@ -91,7 +93,8 @@ public class ChallengeCompletionLogicTest {
             tempDir.resolve("data").resolve("challenge-progress.db"),
             Logger.getAnonymousLogger()
         )) {
-            new ChallengeCompletionLogic(plugin(challengeKey), runtimeConfigs(), challengeConfig("island"), repository);
+            ChallengeLogic challengeLogic = challengeLogic(challengeKey);
+            new ChallengeCompletionLogic(challengeLogic, plugin(challengeLogic), runtimeConfigs(), challengeConfig("island"), repository);
 
             assertTrue(Files.exists(tempDir.resolve("completion")));
             assertTrue(Files.exists(sentinel));
@@ -99,7 +102,7 @@ public class ChallengeCompletionLogicTest {
         }
     }
 
-    private uSkyBlock plugin(ChallengeKey challengeKey) {
+    private ChallengeLogic challengeLogic(ChallengeKey challengeKey) {
         ChallengeLogic challengeLogic = mock(ChallengeLogic.class);
         doAnswer(invocation -> {
             @SuppressWarnings("unchecked")
@@ -107,7 +110,10 @@ public class ChallengeCompletionLogicTest {
             map.put(challengeKey, new ChallengeCompletion(challengeKey, null, 0, 0));
             return null;
         }).when(challengeLogic).populateChallenges(org.mockito.ArgumentMatchers.any());
+        return challengeLogic;
+    }
 
+    private uSkyBlock plugin(ChallengeLogic challengeLogic) {
         uSkyBlock plugin = mock(uSkyBlock.class);
         when(plugin.getChallengeLogic()).thenReturn(challengeLogic);
         when(plugin.getLogger()).thenReturn(Logger.getAnonymousLogger());

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
@@ -4,26 +4,27 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.Material;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.ArgumentCaptor;
 import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfig;
 import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigs;
 import us.talabrek.ultimateskyblock.gameobject.ItemStackSpec;
-import us.talabrek.ultimateskyblock.player.PlayerInfo;
+import us.talabrek.ultimateskyblock.island.IslandKey;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Locale;
+import java.util.UUID;
 import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.any;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ChallengeCompletionLogicTest {
@@ -31,54 +32,120 @@ public class ChallengeCompletionLogicTest {
     Path tempDir;
 
     @Test
-    public void importsLegacyPlayerChallengesIntoRepository() {
-        ChallengeProgressRepository repository = mock(ChallengeProgressRepository.class);
-        when(repository.hasProgress(any())).thenReturn(false);
-        when(repository.load(any())).thenReturn(Map.of());
-
-        ChallengeLogic challengeLogic = mock(ChallengeLogic.class);
+    public void importsLegacyPlayerChallengesDuringStartup() throws Exception {
         ChallengeKey challengeKey = ChallengeKey.of("cobblestonegenerator");
+        writeLegacyPlayerProgress("player-one.yml", 0, 64, 0, challengeKey, 2, 1, 1000L);
+
+        try (ChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
+            tempDir.resolve("challenge-progress.db"),
+            Logger.getAnonymousLogger()
+        )) {
+            ChallengeCompletionLogic logic = new ChallengeCompletionLogic(plugin(challengeKey), runtimeConfigs(), challengeConfig("player"), repository);
+
+            Map<ChallengeKey, ChallengeCompletion> loaded = logic.getIslandChallenges("0,0");
+
+            assertEquals(2, loaded.get(challengeKey).getTimesCompleted());
+            assertEquals(1, loaded.get(challengeKey).getTimesCompletedInCooldown());
+            assertNull(YamlConfiguration.loadConfiguration(tempDir.resolve("players/player-one.yml").toFile()).get("player.challenges"));
+            assertTrue(repository.hasProgress(IslandKey.fromIslandName("0,0")));
+        }
+    }
+
+    @Test
+    public void importsLegacyCompletionFilesDuringStartup() throws Exception {
+        ChallengeKey challengeKey = ChallengeKey.of("cobblestonegenerator");
+        UUID leaderUuid = UUID.randomUUID();
+        long futureCooldown = System.currentTimeMillis() + 60_000L;
+        writeLegacyIsland(leaderUuid, "0,0");
+        writeLegacyCompletionFile(leaderUuid + ".yml", challengeKey, 3, 2, futureCooldown);
+
+        try (ChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
+            tempDir.resolve("challenge-progress.db"),
+            Logger.getAnonymousLogger()
+        )) {
+            ChallengeCompletionLogic logic = new ChallengeCompletionLogic(plugin(challengeKey), runtimeConfigs(), challengeConfig("island"), repository);
+
+            Map<ChallengeKey, ChallengeCompletion> loaded = logic.getIslandChallenges("0,0");
+
+            assertEquals(3, loaded.get(challengeKey).getTimesCompleted());
+            assertEquals(2, loaded.get(challengeKey).getTimesCompletedInCooldown());
+            assertFalse(Files.exists(tempDir.resolve("completion/" + leaderUuid + ".yml")));
+            assertTrue(Files.exists(tempDir.resolve("completion/legacy-backup/" + leaderUuid + ".yml")));
+        }
+    }
+
+    private uSkyBlock plugin(ChallengeKey challengeKey) {
+        ChallengeLogic challengeLogic = mock(ChallengeLogic.class);
         doAnswer(invocation -> {
             @SuppressWarnings("unchecked")
             Map<ChallengeKey, ChallengeCompletion> map = invocation.getArgument(0);
             map.put(challengeKey, new ChallengeCompletion(challengeKey, null, 0, 0));
             return null;
-        }).when(challengeLogic).populateChallenges(any());
+        }).when(challengeLogic).populateChallenges(org.mockito.ArgumentMatchers.any());
 
         uSkyBlock plugin = mock(uSkyBlock.class);
         when(plugin.getChallengeLogic()).thenReturn(challengeLogic);
         when(plugin.getLogger()).thenReturn(Logger.getAnonymousLogger());
         when(plugin.getDataFolder()).thenReturn(tempDir.toFile());
+        return plugin;
+    }
 
+    private RuntimeConfigs runtimeConfigs() {
         RuntimeConfigs runtimeConfigs = mock(RuntimeConfigs.class);
         when(runtimeConfigs.current()).thenReturn(runtimeConfig());
+        return runtimeConfigs;
+    }
 
+    private static YamlConfiguration challengeConfig(String challengeSharing) {
         YamlConfiguration config = new YamlConfiguration();
-        config.set("challengeSharing", "player");
+        config.set("challengeSharing", challengeSharing);
+        return config;
+    }
 
-        ChallengeCompletionLogic logic = new ChallengeCompletionLogic(plugin, runtimeConfigs, config, repository);
-
-        PlayerInfo playerInfo = mock(PlayerInfo.class);
-        when(playerInfo.getHasIsland()).thenReturn(true);
-        when(playerInfo.locationForParty()).thenReturn("0,0");
-        when(playerInfo.getPlayerName()).thenReturn("TestPlayer");
-
+    private void writeLegacyPlayerProgress(
+        String fileName,
+        int islandX,
+        int islandY,
+        int islandZ,
+        ChallengeKey challengeKey,
+        int timesCompleted,
+        int timesCompletedSinceTimer,
+        long firstCompleted
+    ) throws Exception {
+        Path playersDir = tempDir.resolve("players");
+        Files.createDirectories(playersDir);
         YamlConfiguration playerConfig = new YamlConfiguration();
-        playerConfig.set("player.challenges.cobblestonegenerator.firstCompleted", 1000L);
-        playerConfig.set("player.challenges.cobblestonegenerator.timesCompleted", 2);
-        playerConfig.set("player.challenges.cobblestonegenerator.timesCompletedSinceTimer", 1);
-        when(playerInfo.getConfig()).thenReturn(playerConfig);
+        playerConfig.set("player.islandX", islandX);
+        playerConfig.set("player.islandY", islandY);
+        playerConfig.set("player.islandZ", islandZ);
+        playerConfig.set("player.challenges." + challengeKey.id() + ".firstCompleted", firstCompleted);
+        playerConfig.set("player.challenges." + challengeKey.id() + ".timesCompleted", timesCompleted);
+        playerConfig.set("player.challenges." + challengeKey.id() + ".timesCompletedSinceTimer", timesCompletedSinceTimer);
+        playerConfig.save(playersDir.resolve(fileName).toFile());
+    }
 
-        Map<ChallengeKey, ChallengeCompletion> loaded = logic.getChallenges(playerInfo);
+    private void writeLegacyIsland(UUID leaderUuid, String islandName) throws Exception {
+        Path islandsDir = tempDir.resolve("islands");
+        Files.createDirectories(islandsDir);
+        YamlConfiguration islandConfig = new YamlConfiguration();
+        islandConfig.set("party.leader-uuid", leaderUuid.toString());
+        islandConfig.save(islandsDir.resolve(islandName + ".yml").toFile());
+    }
 
-        assertEquals(2, loaded.get(challengeKey).getTimesCompleted());
-        assertEquals(1, loaded.get(challengeKey).getTimesCompletedInCooldown());
-        assertNull(playerConfig.get("player.challenges"));
-        verify(playerInfo).save();
-
-        ArgumentCaptor<Map<ChallengeKey, ChallengeCompletion>> captor = ArgumentCaptor.forClass(Map.class);
-        verify(repository).replace(any(), captor.capture());
-        assertEquals(2, captor.getValue().get(challengeKey).getTimesCompleted());
+    private void writeLegacyCompletionFile(
+        String fileName,
+        ChallengeKey challengeKey,
+        int timesCompleted,
+        int timesCompletedSinceTimer,
+        long firstCompleted
+    ) throws Exception {
+        Path completionDir = tempDir.resolve("completion");
+        Files.createDirectories(completionDir);
+        YamlConfiguration config = new YamlConfiguration();
+        config.set(challengeKey.id() + ".firstCompleted", firstCompleted);
+        config.set(challengeKey.id() + ".timesCompleted", timesCompleted);
+        config.set(challengeKey.id() + ".timesCompletedSinceTimer", timesCompletedSinceTimer);
+        config.save(completionDir.resolve(fileName).toFile());
     }
 
     private static RuntimeConfig runtimeConfig() {

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/SqliteChallengeProgressRepositoryTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/SqliteChallengeProgressRepositoryTest.java
@@ -56,4 +56,17 @@ public class SqliteChallengeProgressRepositoryTest {
         assertFalse(repository.hasProgress(islandKey));
         assertTrue(repository.load(islandKey).isEmpty());
     }
+
+    @Test
+    public void storesMetadata() {
+        SqliteChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
+            tempDir.resolve("data").resolve("challenge-progress.db"),
+            Logger.getAnonymousLogger()
+        );
+
+        repository.putMetadata("legacy_yaml_import_completed", "true");
+
+        assertEquals("1", repository.getMetadata("schema_version").orElseThrow());
+        assertEquals("true", repository.getMetadata("legacy_yaml_import_completed").orElseThrow());
+    }
 }

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/SqliteChallengeProgressRepositoryTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/SqliteChallengeProgressRepositoryTest.java
@@ -21,7 +21,7 @@ public class SqliteChallengeProgressRepositoryTest {
     @Test
     public void storesAndLoadsChallengeProgress() {
         SqliteChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
-            tempDir.resolve("challenge-progress.db"),
+            tempDir.resolve("data").resolve("challenge-progress.db"),
             Logger.getAnonymousLogger()
         );
         IslandKey islandKey = IslandKey.fromIslandName("0,0");
@@ -42,7 +42,7 @@ public class SqliteChallengeProgressRepositoryTest {
     @Test
     public void omitsDefaultProgressRows() {
         SqliteChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
-            tempDir.resolve("challenge-progress.db"),
+            tempDir.resolve("data").resolve("challenge-progress.db"),
             Logger.getAnonymousLogger()
         );
         IslandKey islandKey = IslandKey.fromIslandName("128,256");

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/SqliteChallengeProgressRepositoryTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/SqliteChallengeProgressRepositoryTest.java
@@ -1,0 +1,59 @@
+package us.talabrek.ultimateskyblock.challenge;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import us.talabrek.ultimateskyblock.island.IslandKey;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SqliteChallengeProgressRepositoryTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void storesAndLoadsChallengeProgress() {
+        SqliteChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
+            tempDir.resolve("challenge-progress.db"),
+            Logger.getAnonymousLogger()
+        );
+        IslandKey islandKey = IslandKey.fromIslandName("0,0");
+        ChallengeKey challengeKey = ChallengeKey.of("cobblestonegenerator");
+
+        Map<ChallengeKey, ChallengeCompletion> progress = new HashMap<>();
+        progress.put(challengeKey, new ChallengeCompletion(challengeKey, Instant.ofEpochMilli(1234L), 2, 1));
+
+        repository.replace(islandKey, progress);
+
+        Map<ChallengeKey, ChallengeCompletion> loaded = repository.load(islandKey);
+        assertTrue(repository.hasProgress(islandKey));
+        assertEquals(2, loaded.get(challengeKey).getTimesCompleted());
+        assertEquals(1, loaded.get(challengeKey).getTimesCompletedInCooldown());
+        assertEquals(Instant.ofEpochMilli(1234L), loaded.get(challengeKey).cooldownUntil());
+    }
+
+    @Test
+    public void omitsDefaultProgressRows() {
+        SqliteChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
+            tempDir.resolve("challenge-progress.db"),
+            Logger.getAnonymousLogger()
+        );
+        IslandKey islandKey = IslandKey.fromIslandName("128,256");
+        ChallengeKey challengeKey = ChallengeKey.of("applecollector");
+
+        Map<ChallengeKey, ChallengeCompletion> progress = new HashMap<>();
+        progress.put(challengeKey, new ChallengeCompletion(challengeKey, null, 0, 0));
+
+        repository.replace(islandKey, progress);
+
+        assertFalse(repository.hasProgress(islandKey));
+        assertTrue(repository.load(islandKey).isEmpty());
+    }
+}

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/island/IslandKeyTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/island/IslandKeyTest.java
@@ -1,0 +1,24 @@
+package us.talabrek.ultimateskyblock.island;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class IslandKeyTest {
+
+    @Test
+    public void acceptsLocationDerivedIslandKeys() {
+        assertEquals("128,-256", IslandKey.fromIslandName("128,-256").value());
+    }
+
+    @Test
+    public void rejectsBlankKeys() {
+        assertThrows(IllegalArgumentException.class, () -> new IslandKey(" "));
+    }
+
+    @Test
+    public void rejectsUnexpectedKeyFormats() {
+        assertThrows(IllegalArgumentException.class, () -> new IslandKey("skyworld:128,-256"));
+    }
+}


### PR DESCRIPTION
## Summary
- move challenge progress from legacy YAML files into a SQLite-backed repository
- migrate legacy completion and player challenge data eagerly on first startup into island-owned records
- keep migrated backups under backup/completion and store the DB under data/challenge-progress.db

## Notes
- legacy import is one-shot and tracked in DB metadata so startup does not keep rescanning old files forever
- the repository keeps sparse progress rows and uses WAL mode with a short busy timeout

## Testing
- ./gradlew :uSkyBlock-Core:test --tests us.talabrek.ultimateskyblock.challenge.ChallengeCompletionLogicTest --tests us.talabrek.ultimateskyblock.challenge.SqliteChallengeProgressRepositoryTest --tests us.talabrek.ultimateskyblock.island.IslandKeyTest