### PR TITLE
Fix biome permission node declarations and clearPerms NPE

### DIFF
--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/uSkyBlock.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/uSkyBlock.java
@@ -379,7 +379,7 @@ public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManage
         if (restartConfig.clearInventory()) {
             player.getInventory().clear();
         }
-        if (restartConfig.clearPerms()) {
+        if (restartConfig.clearPerms() && playerInfo != null) {
             playerInfo.clearPerms(player);
         }
         if (restartConfig.clearArmor()) {

--- a/uSkyBlock-Core/src/main/resources/plugin.yml
+++ b/uSkyBlock-Core/src/main/resources/plugin.yml
@@ -188,11 +188,17 @@ permissions:
       usb.biome.nether_wastes: true
       usb.biome.jungle: true
       usb.biome.mushroom_fields: true
-      usb.biome.ocean: false # default: true
+      usb.biome.ocean: true
       usb.biome.plains: true
       usb.biome.the_end: true
       usb.biome.swamp: true
       usb.biome.taiga: true
+      usb.biome.flower_forest: true
+      usb.biome.lukewarm_ocean: true
+      usb.biome.lush_caves: true
+      usb.biome.savanna_plateau: true
+      usb.biome.snowy_plains: true
+      usb.biome.snowy_slopes: true
 
   usb.exempt.*:
     children:
@@ -434,6 +440,30 @@ permissions:
   usb.biome.taiga:
     default: false
     description: 'Let the player change their islands biome to TAIGA'
+
+  usb.biome.flower_forest:
+    default: false
+    description: 'Let the player change their islands biome to FLOWER_FOREST'
+
+  usb.biome.lukewarm_ocean:
+    default: false
+    description: 'Let the player change their islands biome to LUKEWARM_OCEAN'
+
+  usb.biome.lush_caves:
+    default: false
+    description: 'Let the player change their islands biome to LUSH_CAVES'
+
+  usb.biome.savanna_plateau:
+    default: false
+    description: 'Let the player change their islands biome to SAVANNA_PLATEAU'
+
+  usb.biome.snowy_plains:
+    default: false
+    description: 'Let the player change their islands biome to SNOWY_PLAINS'
+
+  usb.biome.snowy_slopes:
+    default: false
+    description: 'Let the player change their islands biome to SNOWY_SLOPES'
 
   usb.donor.100:
     default: false


### PR DESCRIPTION
## Summary
- Declare the six biomes offered by `biomes.yml` but missing from `plugin.yml`: `flower_forest`, `lukewarm_ocean`, `lush_caves`, `savanna_plateau`, `snowy_plains`, `snowy_slopes`. The bundled `challenges.yml` already rewards `usb.biome.flower_forest` (Flower Power, Florist) even though the node was never declared.
- Fix the `usb.biome.*` group child entry for ocean: `usb.biome.ocean: false` inverts the parent grant under Bukkit child semantics, so granting `usb.biome.*` actively **revoked** ocean. The `# default: true` comment shows the original intent ("already default, skip it") — the actual effect was a negation.
- Guard against null `PlayerInfo` in `uSkyBlock.clearPlayerInventory`: `getPlayerInfo` can return null (e.g. maintenance mode) and the `clearPerms` branch dereferenced it unguarded, three lines after the sibling branches null-check the same variable.

## Behavior notes for the changelog
- Declaring the six nodes with `default: false` (consistent with the other twelve) removes the implicit op access that *undeclared* Bukkit nodes get. Ops who relied on op implying the six undeclared biomes need an explicit grant (or `usb.biome.*`).
- `usb.biome.*` now grants ocean instead of revoking it. Setups that relied on the (buggy) revocation would need an explicit negation in their permissions plugin.

## Test Plan
- [x] `:uSkyBlock-Core:build` green (includes test suite)
- [ ] Manual: grant `usb.biome.*` and verify ocean appears in the biome GUI alongside all 18 biomes

These were found while auditing the stale `independent-biome-unlocking` branch; the actual biome-unlocking feature is deferred to the 4.0 challenge rework (issue to follow). These three fixes are correct in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)