### PR TITLE
Harden challenge-progress SQLite storage and legacy migration for 3.5.0

### DIFF
--- a/docs/src/admin/challenges.md
+++ b/docs/src/admin/challenges.md
@@ -22,7 +22,7 @@ These control overall challenge behavior:
 | Key | What it does |
 |---|---|
 | `allowChallenges` | Enable or disable the challenge system entirely |
-| `challengeSharing` | Removed in 3.5.0 — progress is always tracked per island. Legacy per-player progress is merged into the island on first start |
+| `challengeSharing` | Ignored since 3.5.0 — progress is always tracked per island. Leave the key in place for the first start after upgrading: the importer reads it to interpret your legacy progress data correctly |
 | `broadcastCompletion` | Announce first completions server-wide |
 | `requirePreviousRank` | Require earlier ranks before later ranks unlock |
 | `rankLeeway` | How many challenges in a rank can be skipped by default |
@@ -35,7 +35,7 @@ Some of these act as defaults and can be overridden per rank or per challenge, e
 
 ## Progress storage
 
-Since 3.5.0, challenge progress is stored per island in an SQLite database at `plugins/uSkyBlock/data/challenge-progress.db` — include it in your backups. Legacy YAML progress (the `completion/` folder and old per-player data) is imported automatically on the first start after upgrading; imported files are moved to `backup/completion/`. Files that cannot be mapped to an island are left in place and summarized in the server log.
+Since 3.5.0, challenge progress is stored per island in an SQLite database at `plugins/uSkyBlock/data/challenge-progress.db` — include it in your backups. Legacy YAML progress (the `completion/` folder and old per-player data) is imported automatically on the first start after upgrading; imported files are moved to `backup/completion/`. The importer reads your previous `challengeSharing` setting to interpret the legacy data (per-player progress from `challengeSharing: player` setups is merged into each player's island), so do not remove that key before the first start on 3.5.0. Files that cannot be mapped to an island are left in place and summarized in the server log.
 
 The file also defines default GUI colors and locked-menu items.
 

--- a/docs/src/admin/challenges.md
+++ b/docs/src/admin/challenges.md
@@ -22,7 +22,7 @@ These control overall challenge behavior:
 | Key | What it does |
 |---|---|
 | `allowChallenges` | Enable or disable the challenge system entirely |
-| `challengeSharing` | Track progress per `island` or per `player` |
+| `challengeSharing` | Removed in 3.5.0 — progress is always tracked per island. Legacy per-player progress is merged into the island on first start |
 | `broadcastCompletion` | Announce first completions server-wide |
 | `requirePreviousRank` | Require earlier ranks before later ranks unlock |
 | `rankLeeway` | How many challenges in a rank can be skipped by default |
@@ -32,6 +32,10 @@ These control overall challenge behavior:
 | `resetChallengesOnCreate` | Reset progress when an island is created or restarted |
 
 Some of these act as defaults and can be overridden per rank or per challenge, especially `rankLeeway`, `defaultResetInHours`, `radius`, and `repeatLimit`.
+
+## Progress storage
+
+Since 3.5.0, challenge progress is stored per island in an SQLite database at `plugins/uSkyBlock/data/challenge-progress.db` — include it in your backups. Legacy YAML progress (the `completion/` folder and old per-player data) is imported automatically on the first start after upgrading; imported files are moved to `backup/completion/`. Files that cannot be mapped to an island are left in place and summarized in the server log.
 
 The file also defines default GUI colors and locked-menu items.
 

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/bootstrap/SkyblockModule.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/bootstrap/SkyblockModule.java
@@ -76,7 +76,7 @@ public class SkyblockModule extends AbstractModule {
     @Singleton
     public static @NotNull ChallengeProgressRepository provideChallengeProgressRepository(
         @PluginDataDir Path pluginDataDir,
-        Logger logger
+        @PluginLog Logger logger
     ) {
         return new SqliteChallengeProgressRepository(pluginDataDir.resolve("data").resolve("challenge-progress.db"), logger);
     }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogic.java
@@ -4,6 +4,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.jetbrains.annotations.NotNull;
 import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigs;
@@ -11,8 +12,6 @@ import us.talabrek.ultimateskyblock.island.IslandKey;
 import us.talabrek.ultimateskyblock.player.PlayerInfo;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
@@ -27,7 +26,6 @@ public class ChallengeCompletionLogic {
     private final uSkyBlock plugin;
     private final ChallengeLogic challengeLogic;
     private final ChallengeProgressRepository repository;
-    private final Path legacyStorageDir;
     private final boolean legacyPlayerSharingConfigured;
     private final LoadingCache<IslandKey, Map<ChallengeKey, ChallengeCompletion>> completionCache;
 
@@ -41,7 +39,6 @@ public class ChallengeCompletionLogic {
         this.challengeLogic = challengeLogic;
         this.plugin = plugin;
         this.repository = repository;
-        this.legacyStorageDir = plugin.getDataFolder().toPath().resolve("completion");
         legacyPlayerSharingConfigured = config.getString("challengeSharing", "island").equalsIgnoreCase("player");
         if (legacyPlayerSharingConfigured) {
             plugin.getLogger().warning("Legacy challengeSharing=player is deprecated. Challenge progress will be migrated to island-owned database records.");
@@ -60,10 +57,7 @@ public class ChallengeCompletionLogic {
                        }
                    }
             );
-        if (!Files.exists(legacyStorageDir)) {
-            legacyStorageDir.toFile().mkdirs();
-        }
-        new ChallengeProgressMigration(plugin, challengeLogic, repository).migrateLegacyDataEagerly();
+        new ChallengeProgressMigration(plugin, challengeLogic, repository, legacyPlayerSharingConfigured).migrateLegacyDataEagerly();
     }
 
     private Map<ChallengeKey, ChallengeCompletion> loadOrPopulateProgress(IslandKey islandKey) {
@@ -154,7 +148,7 @@ public class ChallengeCompletionLogic {
     private @NotNull Map<ChallengeKey, ChallengeCompletion> getCachedChallenges(@NotNull IslandKey islandKey) {
         try {
             return completionCache.get(islandKey);
-        } catch (ExecutionException e) {
+        } catch (ExecutionException | UncheckedExecutionException e) {
             plugin.getLogger().log(Level.WARNING, "Error fetching challenge-completion for id " + islandKey.value(), e);
             return new HashMap<>();
         }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeLogic.java
@@ -809,8 +809,9 @@ public class ChallengeLogic implements Listener {
         List<String> permissions = new ArrayList<>();
         for (Map.Entry<ChallengeKey, ChallengeCompletion> entry : completions.entrySet()) {
             if (entry.getValue().getTimesCompleted() > 0) {
-                Challenge challenge = getChallengeById(entry.getKey()).orElseThrow();
-                if (challenge.getReward().getPermissionReward() != null) {
+                // Stored progress may reference challenges removed from challenges.yml.
+                Challenge challenge = getChallengeById(entry.getKey()).orElse(null);
+                if (challenge != null && challenge.getReward().getPermissionReward() != null) {
                     permissions.addAll(Arrays.asList(challenge.getReward().getPermissionReward().split(" ")));
                 }
             }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressMigration.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressMigration.java
@@ -31,6 +31,8 @@ final class ChallengeProgressMigration {
 
     private record IslandUuidIndex(Map<UUID, IslandKey> byLeader, Map<UUID, IslandKey> byMember) {}
 
+    private record CompletionScanResult(Set<IslandKey> islands, Set<UUID> players) {}
+
     private static final class MigrationCounters {
         private final AtomicInteger unmapped = new AtomicInteger();
         private final AtomicInteger residue = new AtomicInteger();
@@ -69,8 +71,8 @@ final class ChallengeProgressMigration {
         Map<IslandKey, List<LegacyPlayerProgress>> migratedPlayerConfigs = new HashMap<>();
         MigrationCounters counters = new MigrationCounters();
 
-        Set<IslandKey> islandsWithCompletionFiles = migrateLegacyCompletionFiles(migratedProgress, migratedFiles, counters);
-        migrateLegacyPlayerFiles(migratedProgress, migratedPlayerConfigs, islandsWithCompletionFiles, counters);
+        CompletionScanResult completionFiles = migrateLegacyCompletionFiles(migratedProgress, migratedFiles, counters);
+        migrateLegacyPlayerFiles(migratedProgress, migratedPlayerConfigs, completionFiles, counters);
 
         int migratedIslands = 0;
         for (Map.Entry<IslandKey, Map<ChallengeKey, ChallengeCompletion>> entry : migratedProgress.entrySet()) {
@@ -113,20 +115,20 @@ final class ChallengeProgressMigration {
         return challengeMap;
     }
 
-    private @NotNull Set<IslandKey> migrateLegacyCompletionFiles(
+    private @NotNull CompletionScanResult migrateLegacyCompletionFiles(
         @NotNull Map<IslandKey, Map<ChallengeKey, ChallengeCompletion>> migratedProgress,
         @NotNull Map<IslandKey, List<Path>> migratedFiles,
         @NotNull MigrationCounters counters
     ) {
-        Set<IslandKey> islandsWithCompletionFiles = new HashSet<>();
+        CompletionScanResult result = new CompletionScanResult(new HashSet<>(), new HashSet<>());
         if (!Files.isDirectory(legacyStorageDir)) {
-            return islandsWithCompletionFiles;
+            return result;
         }
         IslandUuidIndex islandIndex = loadIslandUuidIndex();
         try (var files = Files.list(legacyStorageDir)) {
             files.filter(path -> Files.isRegularFile(path) && path.getFileName().toString().endsWith(".yml"))
                 .forEach(path -> {
-                    IslandKey islandKey = resolveLegacyCompletionOwner(path, islandIndex, counters);
+                    IslandKey islandKey = resolveLegacyCompletionOwner(path, islandIndex, result, counters);
                     if (islandKey == null) {
                         return;
                     }
@@ -135,18 +137,18 @@ final class ChallengeProgressMigration {
                         loadLegacyFile(path.toFile())
                     );
                     migratedFiles.computeIfAbsent(islandKey, ignored -> new java.util.ArrayList<>()).add(path);
-                    islandsWithCompletionFiles.add(islandKey);
+                    result.islands().add(islandKey);
                 });
         } catch (Exception e) {
             throw new IllegalStateException("Unable to scan legacy challenge progress directory " + legacyStorageDir, e);
         }
-        return islandsWithCompletionFiles;
+        return result;
     }
 
     private void migrateLegacyPlayerFiles(
         @NotNull Map<IslandKey, Map<ChallengeKey, ChallengeCompletion>> migratedProgress,
         @NotNull Map<IslandKey, List<LegacyPlayerProgress>> migratedPlayerConfigs,
-        @NotNull Set<IslandKey> islandsWithCompletionFiles,
+        @NotNull CompletionScanResult completionFiles,
         @NotNull MigrationCounters counters
     ) {
         if (!Files.isDirectory(playerStorageDir)) {
@@ -172,10 +174,11 @@ final class ChallengeProgressMigration {
                         counters.unmapped.incrementAndGet();
                         return;
                     }
-                    if (islandsWithCompletionFiles.contains(islandKey)) {
-                        // The island already has migrated completion-file progress. The previous
-                        // version only fell back to the player-yml data when no completion file
-                        // existed, so importing it here would resurrect stale state.
+                    if (isPlayerYmlSuperseded(path, islandKey, completionFiles)) {
+                        // The previous version only fell back to the player-yml data when no
+                        // completion file existed (per player under player sharing, per island
+                        // under island sharing), so importing it would resurrect stale state.
+                        counters.residue.incrementAndGet();
                         return;
                     }
                     mergeProgress(
@@ -238,12 +241,20 @@ final class ChallengeProgressMigration {
     private @Nullable IslandKey resolveLegacyCompletionOwner(
         @NotNull Path legacyFile,
         @NotNull IslandUuidIndex islandIndex,
+        @NotNull CompletionScanResult result,
         @NotNull MigrationCounters counters
     ) {
         String fileName = legacyFile.getFileName().toString();
         String basename = fileName.substring(0, fileName.length() - 4);
         try {
-            return IslandKey.fromIslandName(basename);
+            IslandKey islandKey = IslandKey.fromIslandName(basename);
+            if (legacyPlayerSharing) {
+                // Island-named files are stale data from a former challengeSharing=island
+                // setup; the player-sharing runtime never read them.
+                counters.residue.incrementAndGet();
+                return null;
+            }
+            return islandKey;
         } catch (IllegalArgumentException ignored) {
             // fall through
         }
@@ -256,21 +267,59 @@ final class ChallengeProgressMigration {
             return null;
         }
         if (legacyPlayerSharing) {
-            // Per-player progress was live data: attach it to the island the player is a member of.
-            IslandKey islandKey = islandIndex.byMember().get(uuid);
+            // Per-player progress was live data: attach it to the player's island. The player's
+            // own recorded island coordinates are authoritative (the source the previous version
+            // keyed progress by); island membership entries are the fallback for missing player files.
+            IslandKey islandKey = resolvePlayerModeOwner(uuid, islandIndex);
             if (islandKey == null) {
                 plugin.getLogger().warning("No island found for legacy per-player challenge progress " + fileName + ". Leaving file in place.");
                 counters.unmapped.incrementAndGet();
+                return null;
             }
+            result.players().add(uuid);
             return islandKey;
         }
-        // Under island sharing the previous version only promoted the leader's per-player file;
-        // other per-player files are stale data from a former challengeSharing=player setup.
+        // Under island sharing the previous version only promoted the leader's per-player file,
+        // and only when no island-named file existed; everything else is stale data from a
+        // former challengeSharing=player setup.
         IslandKey islandKey = islandIndex.byLeader().get(uuid);
-        if (islandKey == null) {
+        if (islandKey == null || Files.isRegularFile(legacyStorageDir.resolve(islandKey.value() + ".yml"))) {
             counters.residue.incrementAndGet();
+            return null;
         }
         return islandKey;
+    }
+
+    private @Nullable IslandKey resolvePlayerModeOwner(@NotNull UUID uuid, @NotNull IslandUuidIndex islandIndex) {
+        Path playerFile = playerStorageDir.resolve(uuid + ".yml");
+        if (Files.isRegularFile(playerFile)) {
+            YamlConfiguration config = YamlConfiguration.loadConfiguration(playerFile.toFile());
+            if (config.getInt("player.islandY", 0) != 0) {
+                IslandKey byCoordinates = resolvePlayerIslandKey(config);
+                if (byCoordinates != null) {
+                    return byCoordinates;
+                }
+            }
+        }
+        return islandIndex.byMember().get(uuid);
+    }
+
+    private boolean isPlayerYmlSuperseded(
+        @NotNull Path playerFile,
+        @NotNull IslandKey islandKey,
+        @NotNull CompletionScanResult completionFiles
+    ) {
+        if (!legacyPlayerSharing) {
+            return completionFiles.islands().contains(islandKey);
+        }
+        String fileName = playerFile.getFileName().toString();
+        try {
+            UUID playerUuid = UUID.fromString(fileName.substring(0, fileName.length() - 4));
+            return completionFiles.players().contains(playerUuid);
+        } catch (IllegalArgumentException ignored) {
+            // Name-keyed player files predate per-player completion files entirely.
+            return false;
+        }
     }
 
     private @Nullable IslandKey resolvePlayerIslandKey(@NotNull YamlConfiguration config) {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressMigration.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/ChallengeProgressMigration.java
@@ -4,6 +4,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import us.talabrek.ultimateskyblock.island.IslandKey;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 import us.talabrek.ultimateskyblock.util.BackupFileUtil;
@@ -15,18 +16,30 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 
 final class ChallengeProgressMigration {
     private static final String LEGACY_IMPORT_COMPLETED_KEY = "legacy_yaml_import_completed";
+
     private record LegacyPlayerProgress(Path path, YamlConfiguration config) {}
+
+    private record IslandUuidIndex(Map<UUID, IslandKey> byLeader, Map<UUID, IslandKey> byMember) {}
+
+    private static final class MigrationCounters {
+        private final AtomicInteger unmapped = new AtomicInteger();
+        private final AtomicInteger residue = new AtomicInteger();
+    }
 
     private final uSkyBlock plugin;
     private final ChallengeLogic challengeLogic;
     private final ChallengeProgressRepository repository;
+    private final boolean legacyPlayerSharing;
     private final Path legacyStorageDir;
     private final Path playerStorageDir;
     private final Path islandStorageDir;
@@ -34,11 +47,13 @@ final class ChallengeProgressMigration {
     ChallengeProgressMigration(
         @NotNull uSkyBlock plugin,
         @NotNull ChallengeLogic challengeLogic,
-        @NotNull ChallengeProgressRepository repository
+        @NotNull ChallengeProgressRepository repository,
+        boolean legacyPlayerSharing
     ) {
         this.plugin = plugin;
         this.challengeLogic = challengeLogic;
         this.repository = repository;
+        this.legacyPlayerSharing = legacyPlayerSharing;
         this.legacyStorageDir = plugin.getDataFolder().toPath().resolve("completion");
         this.playerStorageDir = plugin.getDataFolder().toPath().resolve("players");
         this.islandStorageDir = plugin.getDataFolder().toPath().resolve("islands");
@@ -52,9 +67,10 @@ final class ChallengeProgressMigration {
         Map<IslandKey, Map<ChallengeKey, ChallengeCompletion>> migratedProgress = new HashMap<>();
         Map<IslandKey, List<Path>> migratedFiles = new HashMap<>();
         Map<IslandKey, List<LegacyPlayerProgress>> migratedPlayerConfigs = new HashMap<>();
+        MigrationCounters counters = new MigrationCounters();
 
-        migrateLegacyCompletionFiles(migratedProgress, migratedFiles);
-        migrateLegacyPlayerFiles(migratedProgress, migratedPlayerConfigs);
+        Set<IslandKey> islandsWithCompletionFiles = migrateLegacyCompletionFiles(migratedProgress, migratedFiles, counters);
+        migrateLegacyPlayerFiles(migratedProgress, migratedPlayerConfigs, islandsWithCompletionFiles, counters);
 
         int migratedIslands = 0;
         for (Map.Entry<IslandKey, Map<ChallengeKey, ChallengeCompletion>> entry : migratedProgress.entrySet()) {
@@ -79,6 +95,15 @@ final class ChallengeProgressMigration {
         cleanupLegacyCompletionDir();
         repository.putMetadata(LEGACY_IMPORT_COMPLETED_KEY, "true");
         plugin.getLogger().info("Migrated legacy challenge progress for " + migratedIslands + " island(s) into SQLite storage.");
+        if (counters.unmapped.get() > 0) {
+            plugin.getLogger().warning("Skipped " + counters.unmapped.get()
+                + " legacy challenge progress source(s) that could not be mapped to an island."
+                + " The files were left in place; see the release notes for details.");
+        }
+        if (counters.residue.get() > 0) {
+            plugin.getLogger().info("Left " + counters.residue.get()
+                + " stale legacy challenge progress source(s) in place; the previous version did not use them either.");
+        }
     }
 
     private @NotNull Map<ChallengeKey, ChallengeCompletion> loadOrPopulateProgress(IslandKey islandKey) {
@@ -88,20 +113,21 @@ final class ChallengeProgressMigration {
         return challengeMap;
     }
 
-    private void migrateLegacyCompletionFiles(
+    private @NotNull Set<IslandKey> migrateLegacyCompletionFiles(
         @NotNull Map<IslandKey, Map<ChallengeKey, ChallengeCompletion>> migratedProgress,
-        @NotNull Map<IslandKey, List<Path>> migratedFiles
+        @NotNull Map<IslandKey, List<Path>> migratedFiles,
+        @NotNull MigrationCounters counters
     ) {
+        Set<IslandKey> islandsWithCompletionFiles = new HashSet<>();
         if (!Files.isDirectory(legacyStorageDir)) {
-            return;
+            return islandsWithCompletionFiles;
         }
-        Map<UUID, IslandKey> islandsByLeader = loadIslandsByLeaderUuid();
+        IslandUuidIndex islandIndex = loadIslandUuidIndex();
         try (var files = Files.list(legacyStorageDir)) {
             files.filter(path -> Files.isRegularFile(path) && path.getFileName().toString().endsWith(".yml"))
                 .forEach(path -> {
-                    IslandKey islandKey = resolveLegacyCompletionOwner(path, islandsByLeader);
+                    IslandKey islandKey = resolveLegacyCompletionOwner(path, islandIndex, counters);
                     if (islandKey == null) {
-                        plugin.getLogger().warning("Unable to resolve legacy challenge progress owner for " + path.getFileName() + ". Leaving file in place.");
                         return;
                     }
                     mergeProgress(
@@ -109,15 +135,19 @@ final class ChallengeProgressMigration {
                         loadLegacyFile(path.toFile())
                     );
                     migratedFiles.computeIfAbsent(islandKey, ignored -> new java.util.ArrayList<>()).add(path);
+                    islandsWithCompletionFiles.add(islandKey);
                 });
         } catch (Exception e) {
-            plugin.getLogger().log(Level.WARNING, "Unable to scan legacy challenge progress directory " + legacyStorageDir, e);
+            throw new IllegalStateException("Unable to scan legacy challenge progress directory " + legacyStorageDir, e);
         }
+        return islandsWithCompletionFiles;
     }
 
     private void migrateLegacyPlayerFiles(
         @NotNull Map<IslandKey, Map<ChallengeKey, ChallengeCompletion>> migratedProgress,
-        @NotNull Map<IslandKey, List<LegacyPlayerProgress>> migratedPlayerConfigs
+        @NotNull Map<IslandKey, List<LegacyPlayerProgress>> migratedPlayerConfigs,
+        @NotNull Set<IslandKey> islandsWithCompletionFiles,
+        @NotNull MigrationCounters counters
     ) {
         if (!Files.isDirectory(playerStorageDir)) {
             return;
@@ -130,9 +160,22 @@ final class ChallengeProgressMigration {
                     if (challengeSection == null || challengeSection.getKeys(false).isEmpty()) {
                         return;
                     }
+                    if (config.getInt("player.islandY", 0) == 0) {
+                        // The player has no island to attach the progress to; the previous version
+                        // never read this data either.
+                        counters.residue.incrementAndGet();
+                        return;
+                    }
                     IslandKey islandKey = resolvePlayerIslandKey(config);
                     if (islandKey == null) {
                         plugin.getLogger().warning("Unable to resolve island owner for legacy player challenge progress in " + path.getFileName() + ". Leaving data in place.");
+                        counters.unmapped.incrementAndGet();
+                        return;
+                    }
+                    if (islandsWithCompletionFiles.contains(islandKey)) {
+                        // The island already has migrated completion-file progress. The previous
+                        // version only fell back to the player-yml data when no completion file
+                        // existed, so importing it here would resurrect stale state.
                         return;
                     }
                     mergeProgress(
@@ -143,38 +186,60 @@ final class ChallengeProgressMigration {
                         .add(new LegacyPlayerProgress(path, config));
                 });
         } catch (Exception e) {
-            plugin.getLogger().log(Level.WARNING, "Unable to scan player data directory " + playerStorageDir + " for legacy challenge progress", e);
+            throw new IllegalStateException("Unable to scan player data directory " + playerStorageDir + " for legacy challenge progress", e);
         }
     }
 
-    private @NotNull Map<UUID, IslandKey> loadIslandsByLeaderUuid() {
-        Map<UUID, IslandKey> islandsByLeader = new HashMap<>();
+    private @NotNull IslandUuidIndex loadIslandUuidIndex() {
+        Map<UUID, IslandKey> byLeader = new HashMap<>();
+        Map<UUID, IslandKey> byMember = new HashMap<>();
         if (!Files.isDirectory(islandStorageDir)) {
-            return islandsByLeader;
+            return new IslandUuidIndex(byLeader, byMember);
         }
         try (var files = Files.list(islandStorageDir)) {
             files.filter(path -> Files.isRegularFile(path) && path.getFileName().toString().endsWith(".yml"))
                 .forEach(path -> {
-                    YamlConfiguration config = YamlConfiguration.loadConfiguration(path.toFile());
-                    String leaderUuid = config.getString("party.leader-uuid", null);
-                    if (leaderUuid == null || leaderUuid.isBlank()) {
+                    String fileName = path.getFileName().toString();
+                    IslandKey islandKey;
+                    try {
+                        islandKey = IslandKey.fromIslandName(fileName.substring(0, fileName.length() - 4));
+                    } catch (IllegalArgumentException ignored) {
+                        // Not an island data file.
                         return;
                     }
-                    try {
-                        String fileName = path.getFileName().toString();
-                        String islandName = fileName.substring(0, fileName.length() - 4);
-                        islandsByLeader.put(UUID.fromString(leaderUuid), IslandKey.fromIslandName(islandName));
-                    } catch (IllegalArgumentException ignored) {
-                        // Ignore invalid leader UUIDs or non-island-named files.
+                    YamlConfiguration config = YamlConfiguration.loadConfiguration(path.toFile());
+                    String leaderUuid = config.getString("party.leader-uuid", null);
+                    if (leaderUuid != null && !leaderUuid.isBlank()) {
+                        try {
+                            UUID uuid = UUID.fromString(leaderUuid);
+                            byLeader.put(uuid, islandKey);
+                            byMember.put(uuid, islandKey);
+                        } catch (IllegalArgumentException ignored) {
+                            // Ignore invalid leader UUIDs.
+                        }
+                    }
+                    ConfigurationSection membersSection = config.getConfigurationSection("party.members");
+                    if (membersSection != null) {
+                        for (String memberKey : membersSection.getKeys(false)) {
+                            try {
+                                byMember.put(UUID.fromString(memberKey), islandKey);
+                            } catch (IllegalArgumentException ignored) {
+                                // Ignore ancient name-keyed member entries.
+                            }
+                        }
                     }
                 });
         } catch (Exception e) {
-            plugin.getLogger().log(Level.WARNING, "Unable to scan island data directory " + islandStorageDir, e);
+            throw new IllegalStateException("Unable to scan island data directory " + islandStorageDir, e);
         }
-        return islandsByLeader;
+        return new IslandUuidIndex(byLeader, byMember);
     }
 
-    private IslandKey resolveLegacyCompletionOwner(@NotNull Path legacyFile, @NotNull Map<UUID, IslandKey> islandsByLeader) {
+    private @Nullable IslandKey resolveLegacyCompletionOwner(
+        @NotNull Path legacyFile,
+        @NotNull IslandUuidIndex islandIndex,
+        @NotNull MigrationCounters counters
+    ) {
         String fileName = legacyFile.getFileName().toString();
         String basename = fileName.substring(0, fileName.length() - 4);
         try {
@@ -182,18 +247,33 @@ final class ChallengeProgressMigration {
         } catch (IllegalArgumentException ignored) {
             // fall through
         }
+        UUID uuid;
         try {
-            return islandsByLeader.get(UUID.fromString(basename));
+            uuid = UUID.fromString(basename);
         } catch (IllegalArgumentException ignored) {
+            plugin.getLogger().warning("Unable to resolve legacy challenge progress owner for " + fileName + ". Leaving file in place.");
+            counters.unmapped.incrementAndGet();
             return null;
         }
+        if (legacyPlayerSharing) {
+            // Per-player progress was live data: attach it to the island the player is a member of.
+            IslandKey islandKey = islandIndex.byMember().get(uuid);
+            if (islandKey == null) {
+                plugin.getLogger().warning("No island found for legacy per-player challenge progress " + fileName + ". Leaving file in place.");
+                counters.unmapped.incrementAndGet();
+            }
+            return islandKey;
+        }
+        // Under island sharing the previous version only promoted the leader's per-player file;
+        // other per-player files are stale data from a former challengeSharing=player setup.
+        IslandKey islandKey = islandIndex.byLeader().get(uuid);
+        if (islandKey == null) {
+            counters.residue.incrementAndGet();
+        }
+        return islandKey;
     }
 
-    private IslandKey resolvePlayerIslandKey(@NotNull YamlConfiguration config) {
-        int islandY = config.getInt("player.islandY", 0);
-        if (islandY == 0) {
-            return null;
-        }
+    private @Nullable IslandKey resolvePlayerIslandKey(@NotNull YamlConfiguration config) {
         int islandX = config.getInt("player.islandX", 0);
         int islandZ = config.getInt("player.islandZ", 0);
         try {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/SqliteChallengeProgressRepository.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/challenge/SqliteChallengeProgressRepository.java
@@ -48,12 +48,16 @@ public class SqliteChallengeProgressRepository implements ChallengeProgressRepos
             statement.setString(1, islandKey.value());
             try (ResultSet rs = statement.executeQuery()) {
                 while (rs.next()) {
-                    Long cooldownUntil = rs.getObject("cooldown_until_ms", Long.class);
+                    // sqlite-jdbc throws "Bad value for type Long" from getObject(..., Long.class) on NULL,
+                    // so NULL cooldowns must be read via getLong + wasNull.
+                    long cooldownMillis = rs.getLong("cooldown_until_ms");
+                    Instant cooldownUntil = rs.wasNull() ? null : Instant.ofEpochMilli(cooldownMillis);
+                    ChallengeKey challengeKey = ChallengeKey.of(rs.getString("challenge_id"));
                     progress.put(
-                        ChallengeKey.of(rs.getString("challenge_id")),
+                        challengeKey,
                         new ChallengeCompletion(
-                            ChallengeKey.of(rs.getString("challenge_id")),
-                            cooldownUntil != null ? Instant.ofEpochMilli(cooldownUntil) : null,
+                            challengeKey,
+                            cooldownUntil,
                             rs.getInt("times_completed"),
                             rs.getInt("times_completed_in_window")
                         )
@@ -108,7 +112,7 @@ public class SqliteChallengeProgressRepository implements ChallengeProgressRepos
                 throw e;
             }
         } catch (SQLException e) {
-            logger.log(Level.FINE, "Unable to store challenge progress for " + islandKey.value(), e);
+            logger.log(Level.WARNING, "Unable to store challenge progress for " + islandKey.value(), e);
             throw new IllegalStateException("Unable to store challenge progress for " + islandKey.value(), e);
         }
     }
@@ -169,7 +173,7 @@ public class SqliteChallengeProgressRepository implements ChallengeProgressRepos
             statement.execute("PRAGMA busy_timeout = " + BUSY_TIMEOUT_MS);
             statement.execute("PRAGMA foreign_keys = ON");
         } catch (SQLException e) {
-            logger.log(Level.FINE, "Unable to apply SQLite connection pragmas", e);
+            logger.log(Level.WARNING, "Unable to apply SQLite connection pragmas", e);
         }
         return connection;
     }

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.logging.Logger;
 
@@ -77,6 +78,85 @@ public class ChallengeCompletionLogicTest {
             assertTrue(Files.exists(tempDir.resolve("backup/completion/" + leaderUuid + ".yml")));
             assertEquals("true", repository.getMetadata("legacy_yaml_import_completed").orElseThrow());
         }
+    }
+
+    @Test
+    public void importsMemberCompletionFilesUnderLegacyPlayerSharing() throws Exception {
+        ChallengeKey challengeKey = ChallengeKey.of("cobblestonegenerator");
+        UUID leaderUuid = UUID.randomUUID();
+        UUID memberUuid = UUID.randomUUID();
+        writeLegacyIsland(leaderUuid, "0,0", memberUuid);
+        writeLegacyCompletionFile(memberUuid + ".yml", challengeKey, 5, 0, 0L);
+
+        try (ChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
+            tempDir.resolve("data").resolve("challenge-progress.db"),
+            Logger.getAnonymousLogger()
+        )) {
+            ChallengeLogic challengeLogic = challengeLogic(challengeKey);
+            ChallengeCompletionLogic logic = new ChallengeCompletionLogic(challengeLogic, plugin(challengeLogic), runtimeConfigs(), challengeConfig("player"), repository);
+
+            Map<ChallengeKey, ChallengeCompletion> loaded = logic.getIslandChallenges("0,0");
+
+            assertEquals(5, loaded.get(challengeKey).getTimesCompleted());
+            assertNull(loaded.get(challengeKey).cooldownUntil());
+            assertFalse(Files.exists(tempDir.resolve("completion/" + memberUuid + ".yml")));
+            assertTrue(Files.exists(tempDir.resolve("backup/completion/" + memberUuid + ".yml")));
+        }
+    }
+
+    @Test
+    public void leavesMemberCompletionFilesUnderIslandSharing() throws Exception {
+        ChallengeKey challengeKey = ChallengeKey.of("cobblestonegenerator");
+        UUID leaderUuid = UUID.randomUUID();
+        UUID memberUuid = UUID.randomUUID();
+        writeLegacyIsland(leaderUuid, "0,0", memberUuid);
+        writeLegacyCompletionFile(memberUuid + ".yml", challengeKey, 5, 0, 0L);
+
+        try (ChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
+            tempDir.resolve("data").resolve("challenge-progress.db"),
+            Logger.getAnonymousLogger()
+        )) {
+            ChallengeLogic challengeLogic = challengeLogic(challengeKey);
+            new ChallengeCompletionLogic(challengeLogic, plugin(challengeLogic), runtimeConfigs(), challengeConfig("island"), repository);
+
+            assertFalse(repository.hasProgress(IslandKey.fromIslandName("0,0")));
+            assertTrue(Files.exists(tempDir.resolve("completion/" + memberUuid + ".yml")));
+            assertEquals("true", repository.getMetadata("legacy_yaml_import_completed").orElseThrow());
+        }
+    }
+
+    @Test
+    public void ignoresPlayerYmlChallengesWhenIslandHasCompletionFile() throws Exception {
+        ChallengeKey challengeKey = ChallengeKey.of("cobblestonegenerator");
+        writeLegacyCompletionFile("0,0.yml", challengeKey, 3, 0, 0L);
+        writeLegacyPlayerProgress("player-one.yml", 0, 64, 0, challengeKey, 9, 9, 1000L);
+
+        try (ChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
+            tempDir.resolve("data").resolve("challenge-progress.db"),
+            Logger.getAnonymousLogger()
+        )) {
+            ChallengeLogic challengeLogic = challengeLogic(challengeKey);
+            ChallengeCompletionLogic logic = new ChallengeCompletionLogic(challengeLogic, plugin(challengeLogic), runtimeConfigs(), challengeConfig("island"), repository);
+
+            Map<ChallengeKey, ChallengeCompletion> loaded = logic.getIslandChallenges("0,0");
+
+            assertEquals(3, loaded.get(challengeKey).getTimesCompleted());
+            assertEquals(9, YamlConfiguration.loadConfiguration(tempDir.resolve("players/player-one.yml").toFile())
+                .getInt("player.challenges." + challengeKey.id() + ".timesCompleted"));
+        }
+    }
+
+    @Test
+    public void returnsEmptyChallengesWhenRepositoryFails() {
+        ChallengeKey challengeKey = ChallengeKey.of("cobblestonegenerator");
+        ChallengeProgressRepository repository = mock(ChallengeProgressRepository.class);
+        when(repository.getMetadata("legacy_yaml_import_completed")).thenReturn(Optional.of("true"));
+        when(repository.load(org.mockito.ArgumentMatchers.any())).thenThrow(new IllegalStateException("database unavailable"));
+
+        ChallengeLogic challengeLogic = challengeLogic(challengeKey);
+        ChallengeCompletionLogic logic = new ChallengeCompletionLogic(challengeLogic, plugin(challengeLogic), runtimeConfigs(), challengeConfig("island"), repository);
+
+        assertTrue(logic.getIslandChallenges("0,0").isEmpty());
     }
 
     @Test
@@ -155,11 +235,15 @@ public class ChallengeCompletionLogicTest {
         playerConfig.save(playersDir.resolve(fileName).toFile());
     }
 
-    private void writeLegacyIsland(UUID leaderUuid, String islandName) throws Exception {
+    private void writeLegacyIsland(UUID leaderUuid, String islandName, UUID... memberUuids) throws Exception {
         Path islandsDir = tempDir.resolve("islands");
         Files.createDirectories(islandsDir);
         YamlConfiguration islandConfig = new YamlConfiguration();
         islandConfig.set("party.leader-uuid", leaderUuid.toString());
+        islandConfig.createSection("party.members." + leaderUuid);
+        for (UUID memberUuid : memberUuids) {
+            islandConfig.createSection("party.members." + memberUuid);
+        }
         islandConfig.save(islandsDir.resolve(islandName + ".yml").toFile());
     }
 

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/ChallengeCompletionLogicTest.java
@@ -126,6 +126,73 @@ public class ChallengeCompletionLogicTest {
     }
 
     @Test
+    public void importsPlayerYmlForMembersWithoutOwnCompletionFileUnderPlayerSharing() throws Exception {
+        ChallengeKey challengeKey = ChallengeKey.of("cobblestonegenerator");
+        UUID leaderUuid = UUID.randomUUID();
+        UUID memberUuid = UUID.randomUUID();
+        writeLegacyIsland(leaderUuid, "0,0", memberUuid);
+        writeLegacyCompletionFile(leaderUuid + ".yml", challengeKey, 3, 0, 0L);
+        writeLegacyPlayerProgress(memberUuid + ".yml", 0, 64, 0, challengeKey, 9, 9, 1000L);
+
+        try (ChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
+            tempDir.resolve("data").resolve("challenge-progress.db"),
+            Logger.getAnonymousLogger()
+        )) {
+            ChallengeLogic challengeLogic = challengeLogic(challengeKey);
+            ChallengeCompletionLogic logic = new ChallengeCompletionLogic(challengeLogic, plugin(challengeLogic), runtimeConfigs(), challengeConfig("player"), repository);
+
+            Map<ChallengeKey, ChallengeCompletion> loaded = logic.getIslandChallenges("0,0");
+
+            // The old player-sharing fallback was gated per player, so the member's
+            // player-yml progress merges even though the leader had a completion file.
+            assertEquals(9, loaded.get(challengeKey).getTimesCompleted());
+        }
+    }
+
+    @Test
+    public void ignoresLeaderCompletionFileWhenIslandFileExistsUnderIslandSharing() throws Exception {
+        ChallengeKey challengeKey = ChallengeKey.of("cobblestonegenerator");
+        UUID leaderUuid = UUID.randomUUID();
+        writeLegacyIsland(leaderUuid, "0,0");
+        writeLegacyCompletionFile("0,0.yml", challengeKey, 3, 0, 0L);
+        writeLegacyCompletionFile(leaderUuid + ".yml", challengeKey, 9, 0, 0L);
+
+        try (ChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
+            tempDir.resolve("data").resolve("challenge-progress.db"),
+            Logger.getAnonymousLogger()
+        )) {
+            ChallengeLogic challengeLogic = challengeLogic(challengeKey);
+            ChallengeCompletionLogic logic = new ChallengeCompletionLogic(challengeLogic, plugin(challengeLogic), runtimeConfigs(), challengeConfig("island"), repository);
+
+            Map<ChallengeKey, ChallengeCompletion> loaded = logic.getIslandChallenges("0,0");
+
+            // The old loader only promoted the leader's file when no island file existed.
+            assertEquals(3, loaded.get(challengeKey).getTimesCompleted());
+            assertTrue(Files.exists(tempDir.resolve("completion/" + leaderUuid + ".yml")));
+        }
+    }
+
+    @Test
+    public void leavesIslandNamedCompletionFilesUnderPlayerSharing() throws Exception {
+        ChallengeKey challengeKey = ChallengeKey.of("cobblestonegenerator");
+        UUID leaderUuid = UUID.randomUUID();
+        writeLegacyIsland(leaderUuid, "0,0");
+        writeLegacyCompletionFile("0,0.yml", challengeKey, 3, 0, 0L);
+
+        try (ChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
+            tempDir.resolve("data").resolve("challenge-progress.db"),
+            Logger.getAnonymousLogger()
+        )) {
+            ChallengeLogic challengeLogic = challengeLogic(challengeKey);
+            new ChallengeCompletionLogic(challengeLogic, plugin(challengeLogic), runtimeConfigs(), challengeConfig("player"), repository);
+
+            // The old player-sharing runtime never read island-named files.
+            assertFalse(repository.hasProgress(IslandKey.fromIslandName("0,0")));
+            assertTrue(Files.exists(tempDir.resolve("completion/0,0.yml")));
+        }
+    }
+
+    @Test
     public void ignoresPlayerYmlChallengesWhenIslandHasCompletionFile() throws Exception {
         ChallengeKey challengeKey = ChallengeKey.of("cobblestonegenerator");
         writeLegacyCompletionFile("0,0.yml", challengeKey, 3, 0, 0L);

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/SqliteChallengeProgressRepositoryTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/challenge/SqliteChallengeProgressRepositoryTest.java
@@ -12,6 +12,7 @@ import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SqliteChallengeProgressRepositoryTest {
@@ -37,6 +38,28 @@ public class SqliteChallengeProgressRepositoryTest {
         assertEquals(2, loaded.get(challengeKey).getTimesCompleted());
         assertEquals(1, loaded.get(challengeKey).getTimesCompletedInCooldown());
         assertEquals(Instant.ofEpochMilli(1234L), loaded.get(challengeKey).cooldownUntil());
+    }
+
+    @Test
+    public void storesAndLoadsProgressWithoutCooldown() {
+        SqliteChallengeProgressRepository repository = new SqliteChallengeProgressRepository(
+            tempDir.resolve("data").resolve("challenge-progress.db"),
+            Logger.getAnonymousLogger()
+        );
+        IslandKey islandKey = IslandKey.fromIslandName("64,-32");
+        ChallengeKey challengeKey = ChallengeKey.of("oncechallenge");
+
+        Map<ChallengeKey, ChallengeCompletion> progress = new HashMap<>();
+        progress.put(challengeKey, new ChallengeCompletion(challengeKey, null, 4, 2));
+
+        repository.replace(islandKey, progress);
+
+        Map<ChallengeKey, ChallengeCompletion> loaded = repository.load(islandKey);
+        assertTrue(repository.hasProgress(islandKey));
+        assertNull(loaded.get(challengeKey).cooldownUntil());
+        assertEquals(4, loaded.get(challengeKey).getTimesCompleted());
+        // Without an active cooldown the window counter collapses to 1 (completed) by design.
+        assertEquals(1, loaded.get(challengeKey).getTimesCompletedInCooldown());
     }
 
     @Test


### PR DESCRIPTION
Pre-release hardening of #137, fixing the confirmed findings from a deep adversarial review of the SQLite challenge-progress feature.

## Release blocker fixed
- **Islands with a completed no-cooldown challenge could not be loaded at all.** sqlite-jdbc's `getObject(column, Long.class)` throws `Bad value for type Long` on SQL NULL instead of returning null, so any island with a stored completion without an active cooldown (e.g. any completed one-time challenge) made `load()` throw on every challenge command, GUI open, and member join. Now read via `getLong` + `wasNull`, with a regression test that fails on master.

## Legacy migration made faithful to the old sharing semantics
The one-shot YAML→SQLite import now reproduces exactly what the pre-SQLite runtime read, per the server's configured `challengeSharing` (per-island is the only model going forward):

- **`challengeSharing: player` servers no longer lose non-leader progress.** Per-player completion files were live data; they're resolved through the player's own recorded island coordinates (deterministic, the source the old runtime keyed by), with island membership (`party.members`) as fallback, and max-merged into the island.
- **`challengeSharing: island` (default) servers no longer resurrect stale data.** Only island-named files and the leader's file (the old loader promoted it when no island file existed — and only then) are imported; other per-player files are residue from a former player-sharing era and stay in place.
- **`players/*.yml` fallback gating matches the old loader:** per player under player sharing, per island under island sharing, never when superseded by a completion file.
- **Scan failures now abort the migration** (and plugin enable) instead of writing the one-shot marker with data unread; per-file YAML corruption still skips gracefully. The migration logs summary counts for unmapped and stale sources.

## Robustness fixes
- The completion cache's graceful-degradation catch could never fire: Guava wraps runtime failures in `UncheckedExecutionException`, not `ExecutionException`. DB read failures now degrade to an empty map with a WARNING instead of uncaught player-facing errors.
- Member-join permission re-grant no longer throws `NoSuchElementException` (aborting all grants) when stored progress references a challenge removed from challenges.yml.
- SQLite repository now gets the plugin logger via `@PluginLog` (was Guice's JIT JUL logger) and logs store/pragma failures at WARNING instead of FINE.
- Removed the dead startup re-creation of the legacy `completion/` directory that undid the migration's cleanup every boot.
- Admin docs: new "Progress storage" section (DB path + backup guidance), `challengeSharing` documented as ignored — with the explicit warning to leave the key in place for the first start after upgrading, since the importer reads it to interpret legacy data.

## Verification
- 9 new tests; 7 fail against master's sources (NULL-cooldown round-trip ×2, member-file import, per-player/per-island yml gating ×2, leader-file precedence, repository-failure fallback). The member-join guard is verified by inspection (constructing `ChallengeLogic` in a test is impractical); the island-sharing residue test pins the no-import invariant.
- The migration changes were themselves adversarially reviewed against the actual pre-SQLite loader (`3599595e`); all confirmed findings from that second pass are fixed in the last commit.
- Full multi-module build green.

Consciously deferred to 4.0 (where the catalog rework replaces the completion runtime): write-behind cache crash window, `PRAGMA synchronous` connection scope, sqlite-jdbc version shadowing by Paper's bundled driver, `IslandKey` strictness. Tracking issue to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)