### PR TITLE
Fix component parsing for 26.1+ servers. fixes #157

### DIFF
--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/util/ItemStackUtil.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/util/ItemStackUtil.java
@@ -288,9 +288,19 @@ public enum ItemStackUtil {
     }
 
     @SuppressWarnings("deprecation")
+    private static String formatItemStack(@NotNull ItemStack itemStack, String dataComponentString) {
+        if (VersionUtil.BUKKIT_VERSION.isLT("26.1")) {
+            return itemStack.getType().getKey() + dataComponentString;
+        }
+        else {
+            return dataComponentString;
+        }
+    }
+
+    @SuppressWarnings("deprecation")
     private static void applyUnsafeDisplayName(@NotNull ItemStack itemStack, @NotNull Component name) {
         String nameJson = GSON_COMPONENT_SERIALIZER.serialize(name);
-        String args = itemStack.getType().getKey() + "[custom_name=" + nameJson + "]";
+        String args = formatItemStack(itemStack, "[custom_name=" + nameJson + "]");
         Bukkit.getUnsafe().modifyItemStack(itemStack, args);
     }
 
@@ -299,7 +309,7 @@ public enum ItemStackUtil {
         String loreEntries = lore.stream()
             .map(GSON_COMPONENT_SERIALIZER::serialize)
             .collect(joining(","));
-        String args = itemStack.getType().getKey() + "[lore=[" + loreEntries + "]]";
+        String args = formatItemStack(itemStack, "[lore=[" + loreEntries + "]]");
         Bukkit.getUnsafe().modifyItemStack(itemStack, args);
     }
 

--- a/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/util/VersionUtil.java
+++ b/bukkit-utils/src/main/java/dk/lockfuglsang/minecraft/util/VersionUtil.java
@@ -1,5 +1,7 @@
 package dk.lockfuglsang.minecraft.util;
 
+import org.bukkit.Bukkit;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -8,6 +10,9 @@ import java.util.regex.Pattern;
  * @since v1.15
  */
 public enum VersionUtil {;
+
+    public static final Version BUKKIT_VERSION = getVersion(Bukkit.getBukkitVersion());
+
     private static final Pattern VERSION_PATTERN = Pattern.compile("v?(?<major>[0-9]+)[\\._](?<minor>[0-9]+)(?:[\\._](?<micro>[0-9]+))?(?<sub>.*)");
     public static Version getVersion(String versionString) {
         Matcher m = VERSION_PATTERN.matcher(versionString);


### PR DESCRIPTION
The breaking change has been made during the 26.1 update.

Commit in Paper repository: https://github.com/PaperMC/Paper/commit/28f8027abbe02be5d3dff1b322c6fadbccb4d658#diff-668fa06459b435c891892632566f83e88390abe112b6ed8f5cbd39ad2720b11fL287-R303

Initial code analysis: https://github.com/uskyblock/uSkyBlock/issues/157

The PS is still in draft because I have not tested it yet.