### PR TITLE
Somes fixes to the build

### DIFF
--- a/docs/src/developers.md
+++ b/docs/src/developers.md
@@ -14,7 +14,7 @@ uSkyBlock is a standard Bukkit plugin. The main components:
 
 ## Building
 
-Requires Java 21. The Gradle wrapper is included.
+Requires Java 21, the [gettext tools](https://www.gnu.org/software/gettext/) and [Perl](https://www.perl.org/get.html). The Gradle wrapper is included.
 
 ```bash
 ./gradlew build

--- a/po-utils/src/test/java/dk/lockfuglsang/minecraft/po/I18nUtilTest.java
+++ b/po-utils/src/test/java/dk/lockfuglsang/minecraft/po/I18nUtilTest.java
@@ -19,6 +19,7 @@ public class I18nUtilTest {
     public void setUp() {
         URL dataFolderUrl = getClass().getClassLoader().getResource("");
         I18nUtil.initialize(new File(dataFolderUrl.getFile()), Locale.ENGLISH);
+        Locale.setDefault(Locale.ENGLISH);
     }
 
     @Test


### PR DESCRIPTION
Here are some minor fixes so I can build the projet on my computer, and possibly other computers that have the same issues.
(Windows 11 25H2, French, IntelliJ IDEA 2026.1.3)

# Changes made

### 1. Set Java default Locale to ENGLISH in I18nUtilTest so the test also works on a non-English computer

Test was failing on `testTrLegacy_nonExistingKeyWithNumberFormatter`, due to the French language rendering "250.25" as "250,25", and due to a different language detection between I18nUtil (that was already forced to English in the unit test file) and the MiniMessage Formatter that was still using the Java default Locale.

### 2. Clarify the need for gettext and Perl in the documentation

Those tools are needed mainly for the translation tool-chain, but it was not ducumented.

# ~~TODO~~

~~Figure out why the build is still stuck on `> Task :uSkyBlock-Core:generateExtraTranslations` even if I have Perl installed (previously, I had an error stating the perl command was not found, now it is just stuck)~~
Will be fixed in another PR
