### PR TITLE
Add Dependabot for Gradle and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+# Dependabot keeps the Gradle version catalog, the Gradle wrapper, and the
+# GitHub Actions used in our workflows up to date.
+# https://docs.github.com/code-security/dependabot
+version: 2
+updates:
+  # ---- Gradle dependencies (gradle/libs.versions.toml + build scripts) ----
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+    groups:
+      # Batch all low-risk (minor/patch) library bumps into a single weekly PR.
+      # Major updates are left as individual PRs so each can be reviewed on its
+      # own -- majors have needed care here before (adventure 4->5, httpclient 4->5).
+      gradle-minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # WorldEdit 7.4.3+ ships Java 25 bytecode; the project targets Java 21.
+      - dependency-name: "com.sk89q.worldedit:worldedit-bukkit"
+        versions: [">= 7.4.3"]
+      # WorldGuard 7.0.16+ declares api-version 1.21.11 and will not enable on the
+      # 1.21.10 minimum-support floor.
+      - dependency-name: "com.sk89q.worldguard:worldguard-bukkit"
+        versions: [">= 7.0.16"]
+      # The spigot-api version is the deliberate minimum-support target, not a bump.
+      - dependency-name: "org.spigotmc:spigot-api"
+
+  # ---- GitHub Actions referenced in .github/workflows ----
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Sets up **Dependabot** so dependency updates arrive as bot PRs instead of manual maintenance batches. Covers the two ecosystems requested — **Gradle** and **GitHub Actions**.

### `gradle`
Watches `gradle/libs.versions.toml`, the build scripts, and the **Gradle wrapper** (wrapper support shipped in dependabot-core #2223, Feb 2026).
- **Minor/patch** bumps are **grouped into one weekly PR** (low churn); **majors** stay individual so each gets its own review — majors have needed care here (adventure 4→5, httpclient 4→5).
- **Ignores** the versions our floors can't take, so Dependabot doesn't open PRs that break the build:
  - `worldedit-bukkit >= 7.4.3` — Java 25 bytecode (project is Java 21).
  - `worldguard-bukkit >= 7.0.16` — `api-version 1.21.11` > the 1.21.10 support floor.
  - `spigot-api` — the deliberate minimum-support target, not a bump.

### `github-actions`
Watches `.github/workflows` (currently tracks checkout, setup-java, setup-gradle, cache, upload-artifact, repository-dispatch, ssh-key-action). All grouped into one weekly PR.

### Note
**Runtime-affecting bumps aren't harness-tested automatically**: the live-server harness runs on schedule / manual dispatch / harness-touching PRs, not on a catalog-only Dependabot PR. Bumps to the `plugin.yml` `libraries:` set (adventure, guava, gson, sqlite, commons-lang3) should get a manual harness run before merge — e.g. adventure-api and adventure-platform-bukkit have separate version keys and must move together. (Optional follow-up: add `gradle/libs.versions.toml` to the harness workflow's PR path triggers to automate this.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)