### PR TITLE
Verify the stable harness lanes on every push and PR

### DIFF
--- a/.github/workflows/live-server-ittest.yml
+++ b/.github/workflows/live-server-ittest.yml
@@ -34,7 +34,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
 
 concurrency:
   # Supersede an in-progress run only for pull requests, where a fresh push makes the
@@ -151,35 +150,10 @@ jobs:
           if-no-files-found: warn
 
       - name: Enforce harness outcome
-        # Supported (pinned) lanes hard-fail: a red run there is always our regression. The
-        # paper-canary lane is handled below - it warns instead of failing the build.
-        if: matrix.lane != 'paper-canary' && steps.harness.outcome == 'failure'
+        # Every lane hard-fails on a red run, canary included: a canary failure is an early warning
+        # of an upstream Paper break, and we want the nightly run to go red so it is not missed.
+        # Canary only runs on the schedule, so failing it never blocks a push or PR merge.
+        if: steps.harness.outcome == 'failure'
         run: |
           echo "Harness failed on ${{ matrix.lane }}. Exit code: ${{ steps.harness.outputs.exit-code }}"
           exit 1
-
-      - name: File or update canary regression issue
-        # The canary tracks the newest AVAILABLE Paper, so a failure is early warning of an upstream
-        # break, not necessarily our regression. Warn via a deduplicated issue and keep the run green.
-        # continue-on-error so a transient gh/API hiccup here can never turn the canary run red.
-        if: matrix.lane == 'paper-canary' && steps.harness.outcome == 'failure'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          title="Canary regression: latest-available Paper"
-          gh label create canary --color FBCA04 --description "Live-server canary (latest-available) regression" 2>/dev/null || true
-          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          existing="$(gh issue list --state open --label canary --json number,title \
-            --jq ".[] | select(.title==\"${title}\") | .number" | head -n1)"
-          if [[ -n "${existing}" ]]; then
-            gh issue comment "${existing}" --body "Recurred: harness exit ${{ steps.harness.outputs.exit-code }} on ${run_url}"
-          else
-            gh issue create --title "${title}" --label canary --body \
-              "The \`paper-canary\` lane (newest available Paper) failed with harness exit ${{ steps.harness.outputs.exit-code }}.
-
-          This lane is non-blocking: a failure here is an early warning of an upstream Paper break, not necessarily a regression in uSkyBlock. Investigate, and if it is a real break, fix it and bump the supported version list (\`gradle.properties\` \`minecraftVersions\`) so the pinned \`paper-max\` lane guards it thereafter.
-
-          Run: ${run_url}"
-          fi

--- a/.github/workflows/live-server-ittest.yml
+++ b/.github/workflows/live-server-ittest.yml
@@ -1,8 +1,16 @@
 name: Live-server integration harness
 
 on:
+  # Nightly: the canary lane only. It tracks the newest AVAILABLE Paper build, so an
+  # upstream break can surface with zero commits of ours. The pinned stable lanes run
+  # on every push and PR, so re-running them on a timer would add nothing.
   schedule:
     - cron: '17 3 * * *'
+  # Every push to master and every PR runs the four pinned stable lanes (no path
+  # filter - a change anywhere can regress runtime behaviour the harness exercises).
+  push:
+    branches: [master]
+  pull_request:
   workflow_dispatch:
     inputs:
       lane:
@@ -28,16 +36,49 @@ permissions:
   contents: read
   issues: write
 
+concurrency:
+  # Supersede an in-progress run only for pull requests, where a fresh push makes the
+  # older run obsolete. Push/schedule/dispatch runs are never cancelled; keying on the
+  # event name as well keeps those event types from serialising against each other.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
-  live_server:
-    # The nightly runs unconditionally: the paper-canary lane tracks the newest available Paper
-    # build, so an upstream break can surface with zero commits of ours - gating on recent commits
-    # would blind exactly the lane that exists to catch it.
+  # Resolve which lanes this event should run:
+  #   schedule                -> paper-canary only (upstream early-warning)
+  #   push (master) / PR      -> the four pinned stable lanes
+  #   workflow_dispatch       -> the dispatched lane, or all five for 'all'
+  select-lanes:
     if: github.repository_owner == 'uskyblock'
+    runs-on: ubuntu-24.04
+    outputs:
+      lanes: ${{ steps.select.outputs.lanes }}
+    steps:
+      - name: Select lanes
+        id: select
+        env:
+          DISPATCH_LANE: ${{ inputs.lane }}
+        run: |
+          case "${{ github.event_name }}" in
+            schedule)
+              lanes='["paper-canary"]' ;;
+            workflow_dispatch)
+              if [[ "${DISPATCH_LANE}" == "all" ]]; then
+                lanes='["paper-min","paper-max","spigot-min","spigot-max","paper-canary"]'
+              else
+                lanes="[\"${DISPATCH_LANE}\"]"
+              fi ;;
+            *)
+              lanes='["paper-min","paper-max","spigot-min","spigot-max"]' ;;
+          esac
+          echo "lanes=${lanes}" >> "${GITHUB_OUTPUT}"
+
+  live_server:
+    needs: select-lanes
     strategy:
       fail-fast: false
       matrix:
-        lane: [paper-min, paper-max, spigot-min, spigot-max, paper-canary]
+        lane: ${{ fromJSON(needs.select-lanes.outputs.lanes) }}
     runs-on: ubuntu-24.04
     # Generous: a cold Spigot BuildTools compile plus two boot/scenario phases with long anti-flake
     # deadlines. Public-repo standard runners are unbilled, so favour reliability over wall-clock.
@@ -59,7 +100,7 @@ jobs:
 
       - name: Cache harness downloads and Spigot builds
         # Persists Paper/WorldEdit/WorldGuard jars, BuildTools, and compiled Spigot server jars
-        # across nightly runs. Keyed per lane and on the pinned version inputs, so the expensive,
+        # across runs. Keyed per lane and on the pinned version inputs, so the expensive,
         # network-heavy Spigot BuildTools compile only re-runs when those change. ~/.m2 caches
         # BuildTools' own Maven downloads to make a cold compile faster and less flaky.
         uses: actions/cache@v4
@@ -73,7 +114,6 @@ jobs:
 
       - name: Run ${{ matrix.lane }}
         id: harness
-        if: github.event_name == 'schedule' || inputs.lane == 'all' || inputs.lane == matrix.lane
         continue-on-error: true
         env:
           OVERRIDE_MINECRAFT: ${{ inputs.minecraft_version }}
@@ -111,8 +151,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Enforce harness outcome
-        # Supported (pinned) lanes hard-fail: a red run there is always our regression. A lane that
-        # was not selected on dispatch is 'skipped' (not 'failure') and must not fail the job. The
+        # Supported (pinned) lanes hard-fail: a red run there is always our regression. The
         # paper-canary lane is handled below - it warns instead of failing the build.
         if: matrix.lane != 'paper-canary' && steps.harness.outcome == 'failure'
         run: |


### PR DESCRIPTION
## What

Gate merges on the live-server harness instead of only running it nightly.

The harness has caught two real runtime regressions in recent PRs that the unit build could not — adventure API/platform skew that only broke on Spigot lanes (#171), and an httpclient5 shutdown race on `paper-max` (#173). Both would have merged green under the old setup. Running the stable lanes per-push/PR closes that gap; at 3–6 min on unbilled public runners, the cost is negligible.

## Trigger split

| Event | Lanes |
|-------|-------|
| `push` to `master`, `pull_request` | `paper-min`, `paper-max`, `spigot-min`, `spigot-max` (pinned, reproducible, always our regression when red) |
| nightly `schedule` | `paper-canary` only (newest-available Paper — a moving upstream target) |
| `workflow_dispatch` | the dispatched lane, or all five for `all` |

- **No path filter** — a change anywhere in the plugin can regress the runtime behaviour these lanes exercise.
- The stable lanes were dropped from the nightly schedule: they already run on every push and PR, so re-running them on a timer added nothing.

## Canary now hard-fails

The canary previously filed a deduplicated issue and kept the run green. That soft signal is easy to miss, so every lane — canary included — now hard-fails on a red run. Because canary only runs on the nightly schedule, failing it turns the nightly red **without ever blocking a push or PR merge**. The bespoke issue-filing step is removed, and workflow permissions are narrowed to `contents: read` (nothing writes issues anymore).

## How

A small `select-lanes` job resolves the lane set for the event and feeds it to the matrix via `fromJSON`, so each event starts exactly the jobs it needs rather than launching all five and skipping the wrong ones. It carries the existing `repository_owner == 'uskyblock'` fork gate; `live_server` inherits it through `needs`.

`concurrency` supersedes an in-progress run only for pull requests (a fresh push obsoletes the old run); push, schedule, and dispatch runs are never cancelled, and keying the group on the event name keeps those event types from serialising against each other.

## Validation

This PR is self-testing: opening it triggers the `pull_request` path, so the four stable lanes exercise the new dynamic-matrix wiring live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)