### PR TITLE
Unit tests for protection listeners + registration gating

### DIFF
--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/bootstrap/ListenersRegistrationTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/bootstrap/ListenersRegistrationTest.java
@@ -1,0 +1,225 @@
+package us.talabrek.ultimateskyblock.bootstrap;
+
+import dk.lockfuglsang.minecraft.util.BukkitServerMock;
+import org.bukkit.Server;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import us.talabrek.ultimateskyblock.chat.ChatEvents;
+import us.talabrek.ultimateskyblock.command.InviteHandler;
+import us.talabrek.ultimateskyblock.config.PluginConfigLoader;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfig;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigFactory;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigs;
+import us.talabrek.ultimateskyblock.event.ExploitEvents;
+import us.talabrek.ultimateskyblock.event.GriefEvents;
+import us.talabrek.ultimateskyblock.event.InternalEvents;
+import us.talabrek.ultimateskyblock.event.ItemDropEvents;
+import us.talabrek.ultimateskyblock.event.MenuEvents;
+import us.talabrek.ultimateskyblock.event.PhantomSpawnEvents;
+import us.talabrek.ultimateskyblock.event.PlayerEvents;
+import us.talabrek.ultimateskyblock.event.PortalEvents;
+import us.talabrek.ultimateskyblock.event.SpawnEvents;
+import us.talabrek.ultimateskyblock.event.ToolMenuEvents;
+import us.talabrek.ultimateskyblock.event.WitherTagEvents;
+import us.talabrek.ultimateskyblock.event.WorldGuardEvents;
+import us.talabrek.ultimateskyblock.gameobject.GameObjectFactory;
+import us.talabrek.ultimateskyblock.gui.GuiListener;
+import us.talabrek.ultimateskyblock.signs.SignEvents;
+import us.talabrek.ultimateskyblock.uuid.PlayerDB;
+
+import java.util.Map;
+import java.util.logging.Logger;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies the flag-gated registration logic in {@link Listeners#registerListeners}. Each conditionally
+ * registered listener is registered iff its runtime-config flag is on; a handful of listeners register
+ * unconditionally.
+ *
+ * <p>The bundled config.yml enables every gate by default, so "flag on" tests use the default config and
+ * "flag off" tests override just the single gate key. The {@code guardianHabitatEvents}
+ * ({@code options.spawning.guardians.enabled}) and {@code netherTerraFormEvents} ({@code nether.enabled})
+ * gates are intentionally not covered here: those listeners reference WorldGuard types
+ * ({@code ProtectedRegion}/{@code ProtectedCuboidRegion}) in their method signatures, so Mockito cannot mock
+ * them without WorldGuard on the test classpath. They are passed as {@code null} and left to the live harness.
+ */
+public class ListenersRegistrationTest {
+
+    private Plugin plugin;
+    private PluginManager manager;
+
+    private InternalEvents internalEvents;
+    private PlayerEvents playerEvents;
+    private PortalEvents portalEvents;
+    private GriefEvents griefEvents;
+    private ItemDropEvents itemDropEvents;
+    private SpawnEvents spawnEvents;
+    private WorldGuardEvents worldGuardEvents;
+    private ToolMenuEvents toolMenuEvents;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        BukkitServerMock.setupServerMock();
+    }
+
+    @Test
+    public void registersAlwaysOnListenersRegardlessOfFlags() {
+        Listeners listeners = buildListeners(loadRuntimeConfig(Map.of()));
+
+        listeners.registerListeners(plugin);
+
+        verify(manager).registerEvents(internalEvents, plugin);
+        verify(manager).registerEvents(playerEvents, plugin);
+        verify(manager).registerEvents(portalEvents, plugin);
+    }
+
+    @Test
+    public void registersGriefEventsWhenProtectionEnabled() {
+        Listeners listeners = buildListeners(loadRuntimeConfig(Map.of()));
+
+        listeners.registerListeners(plugin);
+
+        verify(manager).registerEvents(griefEvents, plugin);
+    }
+
+    @Test
+    public void skipsGriefEventsWhenProtectionDisabled() {
+        Listeners listeners = buildListeners(loadRuntimeConfig(Map.of("options.protection.enabled", false)));
+
+        listeners.registerListeners(plugin);
+
+        verify(manager, never()).registerEvents(griefEvents, plugin);
+    }
+
+    @Test
+    public void registersItemDropEventsWhenProtectionAndItemDropsEnabled() {
+        Listeners listeners = buildListeners(loadRuntimeConfig(Map.of()));
+
+        listeners.registerListeners(plugin);
+
+        verify(manager).registerEvents(itemDropEvents, plugin);
+    }
+
+    @Test
+    public void skipsItemDropEventsWhenItemDropsDisabledButKeepsGriefEvents() {
+        Listeners listeners = buildListeners(loadRuntimeConfig(Map.of("options.protection.item-drops", false)));
+
+        listeners.registerListeners(plugin);
+
+        // Protection is still enabled, so the outer gate still registers griefEvents...
+        verify(manager).registerEvents(griefEvents, plugin);
+        // ...but the inner item-drops gate is off.
+        verify(manager, never()).registerEvents(itemDropEvents, plugin);
+    }
+
+    @Test
+    public void registersSpawnEventsWhenSpawnLimitsEnabled() {
+        Listeners listeners = buildListeners(loadRuntimeConfig(Map.of()));
+
+        listeners.registerListeners(plugin);
+
+        verify(manager).registerEvents(spawnEvents, plugin);
+    }
+
+    @Test
+    public void skipsSpawnEventsWhenSpawnLimitsDisabled() {
+        Listeners listeners = buildListeners(loadRuntimeConfig(Map.of("options.island.spawn-limits.enabled", false)));
+
+        listeners.registerListeners(plugin);
+
+        verify(manager, never()).registerEvents(spawnEvents, plugin);
+    }
+
+    @Test
+    public void registersWorldGuardEventsWhenBlockBannedEntryEnabled() {
+        Listeners listeners = buildListeners(loadRuntimeConfig(Map.of()));
+
+        listeners.registerListeners(plugin);
+
+        verify(manager).registerEvents(worldGuardEvents, plugin);
+    }
+
+    @Test
+    public void skipsWorldGuardEventsWhenBlockBannedEntryDisabled() {
+        Listeners listeners = buildListeners(loadRuntimeConfig(Map.of("options.protection.visitors.block-banned-entry", false)));
+
+        listeners.registerListeners(plugin);
+
+        verify(manager, never()).registerEvents(worldGuardEvents, plugin);
+    }
+
+    @Test
+    public void registersToolMenuEventsWhenToolMenuEnabled() {
+        Listeners listeners = buildListeners(loadRuntimeConfig(Map.of()));
+
+        listeners.registerListeners(plugin);
+
+        verify(manager).registerEvents(toolMenuEvents, plugin);
+    }
+
+    @Test
+    public void skipsToolMenuEventsWhenToolMenuDisabled() {
+        Listeners listeners = buildListeners(loadRuntimeConfig(Map.of("tool-menu.enabled", false)));
+
+        listeners.registerListeners(plugin);
+
+        verify(manager, never()).registerEvents(toolMenuEvents, plugin);
+    }
+
+    private RuntimeConfig loadRuntimeConfig(Map<String, Object> overrides) {
+        YamlConfiguration config = new YamlConfiguration();
+        config.setDefaults(PluginConfigLoader.loadBundledConfig());
+        overrides.forEach(config::set);
+        return new RuntimeConfigFactory(new GameObjectFactory(), Logger.getAnonymousLogger()).load(config);
+    }
+
+    private Listeners buildListeners(RuntimeConfig runtimeConfig) {
+        RuntimeConfigs runtimeConfigs = mock(RuntimeConfigs.class);
+        when(runtimeConfigs.current()).thenReturn(runtimeConfig);
+
+        plugin = mock(Plugin.class);
+        manager = mock(PluginManager.class);
+        Server server = mock(Server.class);
+        when(plugin.getServer()).thenReturn(server);
+        when(server.getPluginManager()).thenReturn(manager);
+
+        internalEvents = mock(InternalEvents.class);
+        playerEvents = mock(PlayerEvents.class);
+        portalEvents = mock(PortalEvents.class);
+        griefEvents = mock(GriefEvents.class);
+        itemDropEvents = mock(ItemDropEvents.class);
+        spawnEvents = mock(SpawnEvents.class);
+        worldGuardEvents = mock(WorldGuardEvents.class);
+        toolMenuEvents = mock(ToolMenuEvents.class);
+
+        return new Listeners(
+            runtimeConfigs,
+            mock(GuiListener.class),
+            internalEvents,
+            playerEvents,
+            mock(MenuEvents.class),
+            mock(ExploitEvents.class),
+            portalEvents,
+            mock(WitherTagEvents.class),
+            griefEvents,
+            itemDropEvents,
+            spawnEvents,
+            mock(PhantomSpawnEvents.class),
+            null, // guardianHabitatEvents: references WorldGuard types in method signatures, not mockable here
+            worldGuardEvents,
+            null, // netherTerraFormEvents: references WorldGuard types in method signatures, not mockable here
+            toolMenuEvents,
+            mock(SignEvents.class),
+            mock(ChatEvents.class),
+            mock(InviteHandler.class),
+            mock(PlayerDB.class)
+        );
+    }
+}

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/event/ExploitEventsTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/event/ExploitEventsTest.java
@@ -1,0 +1,211 @@
+package us.talabrek.ultimateskyblock.event;
+
+import dk.lockfuglsang.minecraft.po.I18nUtil;
+import dk.lockfuglsang.minecraft.util.BukkitServerMock;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Vehicle;
+import org.bukkit.event.player.PlayerPortalEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.vehicle.VehicleDamageEvent;
+import org.bukkit.event.vehicle.VehicleDestroyEvent;
+import org.bukkit.event.vehicle.VehicleEnterEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import us.talabrek.ultimateskyblock.config.PluginConfigLoader;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfig;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigFactory;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigs;
+import us.talabrek.ultimateskyblock.gameobject.GameObjectFactory;
+import us.talabrek.ultimateskyblock.island.IslandInfo;
+import us.talabrek.ultimateskyblock.message.Msg;
+import us.talabrek.ultimateskyblock.uSkyBlock;
+import us.talabrek.ultimateskyblock.world.WorldManager;
+
+import java.io.File;
+import java.util.Locale;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for the exploit protection visitor decisions in {@link ExploitEvents} that are reachable
+ * through mockable collaborators (config flags, {@code plugin.playerIsOnIsland(...)}, {@link IslandInfo}
+ * mocks). The WorldGuard-backed island lookups are exercised by the live-server harness instead.
+ */
+public class ExploitEventsTest {
+    private static final String KEY_VILLAGER_TRADING_ENABLED = "options.protection.villager-trading-enabled";
+    private static final String KEY_VISITOR_USE_PORTALS = "options.protection.visitors.use-portals";
+    private static final String KEY_VISITOR_VEHICLE_ENTER = "options.protection.visitors.vehicle-enter";
+    private static final String KEY_VISITOR_VEHICLE_DAMAGE = "options.protection.visitors.vehicle-damage";
+
+    private uSkyBlock plugin;
+    private WorldManager worldManager;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        BukkitServerMock.setupServerMock();
+        I18nUtil.initialize(new File("."), Locale.ENGLISH);
+        Msg.configure((sender, message) -> {});
+
+        plugin = mock(uSkyBlock.class);
+        worldManager = mock(WorldManager.class);
+        when(plugin.getWorldManager()).thenReturn(worldManager);
+        when(worldManager.isSkyAssociatedWorld(any())).thenReturn(true);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Msg.configure(null);
+    }
+
+    // The villager-trade branches that reach `InventoryType.MERCHANT` (globally-blocked, visitor-blocked,
+    // owner-allowed) are intentionally not unit-tested: referencing any InventoryType constant initializes
+    // org.bukkit.Registry, which throws "No registry present" without a live server. Those branches are left
+    // to the live-server harness. Only the early-return (non-sky world) branch, which never touches the
+    // inventory, is covered here.
+    @Test
+    public void villagerTradeIgnoredOutsideSkyworld() {
+        ExploitEvents events = exploitEventsWith(Map.of(KEY_VILLAGER_TRADING_ENABLED, false));
+        World nonSkyWorld = mock(World.class);
+        when(worldManager.isSkyAssociatedWorld(nonSkyWorld)).thenReturn(false);
+        Player player = mock(Player.class);
+        when(player.getWorld()).thenReturn(nonSkyWorld);
+        InventoryOpenEvent event = mock(InventoryOpenEvent.class);
+        when(event.getPlayer()).thenReturn(player);
+
+        events.onVillagerTrade(event);
+
+        verify(event, never()).setCancelled(anyBoolean());
+    }
+
+    @Test
+    public void portalUseCancelledForNonOwnerVisitor() {
+        ExploitEvents events = exploitEventsWith(Map.of(KEY_VISITOR_USE_PORTALS, false));
+        World world = mock(World.class);
+        Player player = mock(Player.class);
+        Location to = new Location(world, 10, 60, 10);
+        Location from = new Location(world, 0, 60, 0);
+        PlayerPortalEvent event = mock(PlayerPortalEvent.class);
+        when(event.getPlayer()).thenReturn(player);
+        when(event.getTo()).thenReturn(to);
+        when(event.getFrom()).thenReturn(from);
+        when(event.getCause()).thenReturn(PlayerTeleportEvent.TeleportCause.NETHER_PORTAL);
+
+        when(plugin.playerIsOnIsland(player)).thenReturn(false);
+        when(plugin.playerIsInSpawn(player)).thenReturn(false);
+        IslandInfo islandInfo = mock(IslandInfo.class);
+        when(plugin.getIslandInfo(player)).thenReturn(islandInfo);
+        when(islandInfo.contains(to)).thenReturn(false);
+        when(islandInfo.contains(from)).thenReturn(false);
+
+        events.onPortalEvent(event);
+
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    public void portalUseAllowedWhenDestinationIsOwnIsland() {
+        ExploitEvents events = exploitEventsWith(Map.of(KEY_VISITOR_USE_PORTALS, false));
+        World world = mock(World.class);
+        Player player = mock(Player.class);
+        Location to = new Location(world, 10, 60, 10);
+        Location from = new Location(world, 0, 60, 0);
+        PlayerPortalEvent event = mock(PlayerPortalEvent.class);
+        when(event.getPlayer()).thenReturn(player);
+        when(event.getTo()).thenReturn(to);
+        when(event.getFrom()).thenReturn(from);
+        when(event.getCause()).thenReturn(PlayerTeleportEvent.TeleportCause.NETHER_PORTAL);
+
+        when(plugin.playerIsOnIsland(player)).thenReturn(false);
+        when(plugin.playerIsInSpawn(player)).thenReturn(false);
+        IslandInfo islandInfo = mock(IslandInfo.class);
+        when(plugin.getIslandInfo(player)).thenReturn(islandInfo);
+        when(islandInfo.contains(to)).thenReturn(true);
+
+        events.onPortalEvent(event);
+
+        verify(event, never()).setCancelled(anyBoolean());
+    }
+
+    @Test
+    public void vehicleEnterCancelledForVisitor() {
+        ExploitEvents events = exploitEventsWith(Map.of(KEY_VISITOR_VEHICLE_ENTER, false));
+        Player player = mock(Player.class);
+        when(plugin.playerIsOnIsland(player)).thenReturn(false);
+        Vehicle vehicle = skyVehicle();
+        VehicleEnterEvent event = mock(VehicleEnterEvent.class);
+        when(event.getEntered()).thenReturn(player);
+        when(event.getVehicle()).thenReturn(vehicle);
+
+        events.on(event);
+
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    public void vehicleEnterAllowedForVisitorOnOwnIsland() {
+        ExploitEvents events = exploitEventsWith(Map.of(KEY_VISITOR_VEHICLE_ENTER, false));
+        Player player = mock(Player.class);
+        when(plugin.playerIsOnIsland(player)).thenReturn(true);
+        Vehicle vehicle = skyVehicle();
+        VehicleEnterEvent event = mock(VehicleEnterEvent.class);
+        when(event.getEntered()).thenReturn(player);
+        when(event.getVehicle()).thenReturn(vehicle);
+
+        events.on(event);
+
+        verify(event, never()).setCancelled(anyBoolean());
+    }
+
+    @Test
+    public void vehicleDamageCancelledForVisitor() {
+        ExploitEvents events = exploitEventsWith(Map.of(KEY_VISITOR_VEHICLE_DAMAGE, false));
+        Player player = mock(Player.class);
+        when(plugin.playerIsOnIsland(player)).thenReturn(false);
+        Vehicle vehicle = skyVehicle();
+        VehicleDamageEvent event = mock(VehicleDamageEvent.class);
+        when(event.getAttacker()).thenReturn(player);
+        when(event.getVehicle()).thenReturn(vehicle);
+
+        events.on(event);
+
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    public void vehicleDestroyCancelledForVisitor() {
+        ExploitEvents events = exploitEventsWith(Map.of(KEY_VISITOR_VEHICLE_DAMAGE, false));
+        Player player = mock(Player.class);
+        when(plugin.playerIsOnIsland(player)).thenReturn(false);
+        Vehicle vehicle = skyVehicle();
+        VehicleDestroyEvent event = mock(VehicleDestroyEvent.class);
+        when(event.getAttacker()).thenReturn(player);
+        when(event.getVehicle()).thenReturn(vehicle);
+
+        events.on(event);
+
+        verify(event).setCancelled(true);
+    }
+
+    private Vehicle skyVehicle() {
+        Vehicle vehicle = mock(Vehicle.class);
+        when(vehicle.getWorld()).thenReturn(mock(World.class));
+        return vehicle;
+    }
+
+    private ExploitEvents exploitEventsWith(Map<String, Object> protectionOverrides) {
+        YamlConfiguration config = new YamlConfiguration();
+        config.setDefaults(PluginConfigLoader.loadBundledConfig());
+        protectionOverrides.forEach(config::set);
+        RuntimeConfig runtimeConfig = new RuntimeConfigFactory(new GameObjectFactory(), Logger.getAnonymousLogger()).load(config);
+        RuntimeConfigs runtimeConfigs = mock(RuntimeConfigs.class);
+        doReturn(runtimeConfig).when(runtimeConfigs).current();
+        return new ExploitEvents(plugin, runtimeConfigs);
+    }
+}

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/event/GriefEventsProtectionTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/event/GriefEventsProtectionTest.java
@@ -1,0 +1,263 @@
+package us.talabrek.ultimateskyblock.event;
+
+import dk.lockfuglsang.minecraft.util.BukkitServerMock;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Creature;
+import org.bukkit.entity.Creeper;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.TNTPrimed;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.ExplosionPrimeEvent;
+import org.bukkit.event.player.PlayerEggThrowEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerShearEntityEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import us.talabrek.ultimateskyblock.config.PluginConfigLoader;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigFactory;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigs;
+import us.talabrek.ultimateskyblock.gameobject.GameObjectFactory;
+import us.talabrek.ultimateskyblock.island.LimitLogic;
+import us.talabrek.ultimateskyblock.uSkyBlock;
+import us.talabrek.ultimateskyblock.world.WorldManager;
+
+import java.util.Arrays;
+import java.util.logging.Logger;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for the mockable, environmental decisions in {@link GriefEvents}.
+ *
+ * <p>The wither-rampage branches ({@code onTargeting} / {@code onWitherSkullExplosion}) are not
+ * covered here: they depend on {@code WorldGuardHandler.getIslandNameAt(...)} cross-island geometry,
+ * which is not available on the unit-test classpath. Those are left for the live-server harness.
+ */
+public class GriefEventsProtectionTest {
+
+    private uSkyBlock plugin;
+    private WorldManager worldManager;
+    private GriefEvents griefEvents;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        BukkitServerMock.setupServerMock();
+        plugin = mock(uSkyBlock.class);
+
+        // Load a REAL RuntimeConfig from the bundled defaults; all protection flags default to true.
+        YamlConfiguration config = new YamlConfiguration();
+        config.setDefaults(PluginConfigLoader.loadBundledConfig());
+        config.set("options.party.join-commands", Arrays.asList("lets", "test", "this"));
+        config.set("options.party.leave-commands", Arrays.asList("dont", "stop", "me", "now"));
+        config.set("language", "en");
+        config.set("options.general.worldName", "skyworld");
+        config.set("options.general.cooldownRestart", "1m");
+        config.set("options.general.biomeChange", "1m");
+        config.set("options.general.defaultBiome", "plains");
+        config.set("options.general.defaultNetherBiome", "nether_wastes");
+        config.set("options.advanced.confirmTimeout", "30s");
+        config.set("options.advanced.playerdb.storage", "file");
+        config.set("options.advanced.playerdb.nameCache", "maximumSize=100");
+        config.set("options.advanced.playerdb.uuidCache", "maximumSize=100");
+        config.set("options.advanced.playerCache", "maximumSize=100");
+        config.set("options.advanced.islandCache", "maximumSize=100");
+        config.set("options.advanced.island.saveEvery", 60);
+        config.set("options.advanced.player.saveEvery", 60);
+        config.set("options.party.invite-timeout", "1m");
+        config.set("options.island.distance", 110);
+        config.set("options.island.height", 120);
+        config.set("options.island.topTenTimeout", "15m");
+        config.set("options.island.islandTeleportDelay", "2s");
+        config.set("options.island.chat-format", "default");
+        config.set("options.party.chat-format", "default");
+        config.set("nether.chunk-generator", "default");
+        config.set("plugin-updates.branch", "LATEST");
+
+        RuntimeConfigs runtimeConfigs = mock(RuntimeConfigs.class);
+        doReturn(new RuntimeConfigFactory(new GameObjectFactory(), Logger.getAnonymousLogger()).load(config))
+            .when(runtimeConfigs).current();
+
+        griefEvents = new GriefEvents(plugin, runtimeConfigs);
+
+        // Every handler first checks that the event happens in a sky-associated world.
+        worldManager = mock(WorldManager.class);
+        doReturn(true).when(worldManager).isSkyAssociatedWorld(any());
+        doReturn(worldManager).when(plugin).getWorldManager();
+    }
+
+    @Test
+    public void creeperTargetingVisitorIsCancelled() {
+        Player visitor = mock(Player.class);
+        doReturn(false).when(plugin).playerIsOnIsland(visitor);
+
+        Creeper creeper = mock(Creeper.class);
+        doReturn(visitor).when(creeper).getTarget();
+
+        ExplosionPrimeEvent event = mock(ExplosionPrimeEvent.class);
+        doReturn(creeper).when(event).getEntity();
+
+        griefEvents.onCreeperExplode(event);
+
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    public void creeperTargetingIslandPlayerIsNotCancelled() {
+        Player member = mock(Player.class);
+        doReturn(true).when(plugin).playerIsOnIsland(member);
+
+        Creeper creeper = mock(Creeper.class);
+        doReturn(member).when(creeper).getTarget();
+
+        ExplosionPrimeEvent event = mock(ExplosionPrimeEvent.class);
+        doReturn(creeper).when(event).getEntity();
+
+        griefEvents.onCreeperExplode(event);
+
+        verify(event, never()).setCancelled(true);
+    }
+
+    @Test
+    public void tntPrimedByVisitorIsCancelled() {
+        Player visitor = mock(Player.class);
+        doReturn(false).when(plugin).playerIsOnIsland(visitor);
+
+        TNTPrimed tnt = mock(TNTPrimed.class);
+        doReturn(visitor).when(tnt).getSource();
+
+        ExplosionPrimeEvent event = mock(ExplosionPrimeEvent.class);
+        doReturn(tnt).when(event).getEntity();
+
+        griefEvents.onCreeperExplode(event);
+
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    public void shearingByVisitorIsCancelled() {
+        Player visitor = mock(Player.class);
+        doReturn(false).when(plugin).playerIsOnIsland(visitor);
+
+        PlayerShearEntityEvent event = mock(PlayerShearEntityEvent.class);
+        doReturn(visitor).when(event).getPlayer();
+
+        griefEvents.onShearEvent(event);
+
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    public void shearingByIslandPlayerIsNotCancelled() {
+        Player member = mock(Player.class);
+        doReturn(true).when(plugin).playerIsOnIsland(member);
+
+        PlayerShearEntityEvent event = mock(PlayerShearEntityEvent.class);
+        doReturn(member).when(event).getPlayer();
+
+        griefEvents.onShearEvent(event);
+
+        verify(event, never()).setCancelled(true);
+    }
+
+    @Test
+    public void tramplingFarmlandByVisitorIsCancelled() {
+        Player visitor = mock(Player.class);
+        doReturn(false).when(plugin).playerIsOnIsland(visitor);
+
+        Block block = mock(Block.class);
+        doReturn(Material.FARMLAND).when(block).getType();
+
+        PlayerInteractEvent event = mock(PlayerInteractEvent.class);
+        doReturn(visitor).when(event).getPlayer();
+        doReturn(Action.PHYSICAL).when(event).getAction();
+        doReturn(true).when(event).hasBlock();
+        doReturn(block).when(event).getClickedBlock();
+
+        griefEvents.onTrampling(event);
+
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    public void eggThrowByVisitorDoesNotHatch() {
+        Player visitor = mock(Player.class);
+        doReturn(false).when(plugin).playerIsOnIsland(visitor);
+
+        PlayerEggThrowEvent event = mock(PlayerEggThrowEvent.class);
+        doReturn(visitor).when(event).getPlayer();
+
+        griefEvents.onEgg(event);
+
+        verify(event).setHatching(false);
+    }
+
+    @Test
+    public void eggThrowByIslandPlayerHatchesNormally() {
+        Player member = mock(Player.class);
+        doReturn(true).when(plugin).playerIsOnIsland(member);
+
+        PlayerEggThrowEvent event = mock(PlayerEggThrowEvent.class);
+        doReturn(member).when(event).getPlayer();
+
+        griefEvents.onEgg(event);
+
+        verify(event, never()).setHatching(anyBoolean());
+    }
+
+    @Test
+    public void killAnimalByVisitorIsCancelled() {
+        Player visitor = mock(Player.class);
+        doReturn(false).when(plugin).playerIsOnIsland(visitor);
+
+        Creature animal = mock(Creature.class);
+        LimitLogic limitLogic = mock(LimitLogic.class);
+        doReturn(LimitLogic.CreatureType.ANIMAL).when(limitLogic).getCreatureType(animal);
+        doReturn(limitLogic).when(plugin).getLimitLogic();
+
+        EntityDamageByEntityEvent event = mock(EntityDamageByEntityEvent.class);
+        doReturn(visitor).when(event).getDamager();
+        doReturn(animal).when(event).getEntity();
+
+        griefEvents.onEntityDamage(event);
+
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    public void killMonsterByVisitorIsCancelled() {
+        Player visitor = mock(Player.class);
+        doReturn(false).when(plugin).playerIsOnIsland(visitor);
+
+        Creature monster = mock(Creature.class);
+        LimitLogic limitLogic = mock(LimitLogic.class);
+        doReturn(LimitLogic.CreatureType.MONSTER).when(limitLogic).getCreatureType(monster);
+        doReturn(limitLogic).when(plugin).getLimitLogic();
+
+        EntityDamageByEntityEvent event = mock(EntityDamageByEntityEvent.class);
+        doReturn(visitor).when(event).getDamager();
+        doReturn(monster).when(event).getEntity();
+
+        griefEvents.onEntityDamage(event);
+
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    public void damageByIslandPlayerIsNotCancelled() {
+        Player member = mock(Player.class);
+        doReturn(true).when(plugin).playerIsOnIsland(member);
+
+        Creature animal = mock(Creature.class);
+
+        EntityDamageByEntityEvent event = mock(EntityDamageByEntityEvent.class);
+        doReturn(member).when(event).getDamager();
+        doReturn(animal).when(event).getEntity();
+
+        griefEvents.onEntityDamage(event);
+
+        verify(event, never()).setCancelled(true);
+    }
+}

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/event/ItemDropEventsTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/event/ItemDropEventsTest.java
@@ -1,0 +1,199 @@
+package us.talabrek.ultimateskyblock.event;
+
+import dk.lockfuglsang.minecraft.po.I18nUtil;
+import dk.lockfuglsang.minecraft.util.BukkitServerMock;
+import org.bukkit.World;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import us.talabrek.ultimateskyblock.config.PluginConfigLoader;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfig;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigFactory;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigs;
+import us.talabrek.ultimateskyblock.gameobject.GameObjectFactory;
+import us.talabrek.ultimateskyblock.uSkyBlock;
+import us.talabrek.ultimateskyblock.world.WorldManager;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.logging.Logger;
+
+import static net.kyori.adventure.text.minimessage.tag.resolver.Placeholder.unparsed;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+public class ItemDropEventsTest {
+    private uSkyBlock plugin;
+    private WorldManager worldManager;
+    private ItemDropEvents itemDropEvents;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        BukkitServerMock.setupServerMock();
+        I18nUtil.initialize(new File("."), Locale.ENGLISH);
+
+        plugin = mock(uSkyBlock.class);
+        worldManager = mock(WorldManager.class);
+        doReturn(worldManager).when(plugin).getWorldManager();
+
+        // visitors are NOT allowed to drop items
+        itemDropEvents = new ItemDropEvents(plugin, runtimeConfigs(false));
+    }
+
+    @Test
+    public void dropTagsItemWithOwnerLoreForResident() {
+        World world = mock(World.class);
+        Player player = mock(Player.class);
+        doReturn(world).when(player).getWorld();
+        doReturn("Notch").when(player).getName();
+
+        ItemMeta meta = mock(ItemMeta.class);
+        doReturn(null).when(meta).getLore();
+        ItemStack stack = mock(ItemStack.class);
+        doReturn(meta).when(stack).getItemMeta();
+        Item itemEntity = mock(Item.class);
+        doReturn(stack).when(itemEntity).getItemStack();
+
+        PlayerDropItemEvent event = mock(PlayerDropItemEvent.class);
+        doReturn(player).when(event).getPlayer();
+        doReturn(itemEntity).when(event).getItemDrop();
+
+        doReturn(true).when(worldManager).isSkyAssociatedWorld(world);
+        doReturn(true).when(plugin).playerIsOnIsland(player);
+        doReturn(false).when(plugin).playerIsInSpawn(player);
+
+        itemDropEvents.onDropEvent(event);
+
+        String ownerTag = I18nUtil.trLegacy("Owner: <player>", unparsed("player", "Notch"));
+        ArgumentCaptor<List> loreCaptor = ArgumentCaptor.forClass(List.class);
+        verify(meta).setLore(loreCaptor.capture());
+        assertTrue(loreCaptor.getValue().contains(ownerTag));
+        verify(stack).setItemMeta(meta);
+        verify(event, never()).setCancelled(true);
+    }
+
+    @Test
+    public void dropIsBlockedForVisitor() {
+        World world = mock(World.class);
+        Player player = mock(Player.class);
+        doReturn(world).when(player).getWorld();
+
+        PlayerDropItemEvent event = mock(PlayerDropItemEvent.class);
+        doReturn(player).when(event).getPlayer();
+
+        doReturn(true).when(worldManager).isSkyAssociatedWorld(world);
+        doReturn(false).when(plugin).playerIsOnIsland(player);
+        doReturn(false).when(plugin).playerIsInSpawn(player);
+
+        itemDropEvents.onDropEvent(event);
+
+        verify(event).setCancelled(true);
+        verify(plugin).notifyPlayer(eq(player), any());
+        verify(event, never()).getItemDrop();
+    }
+
+    @Test
+    public void deathKeepsInventoryForVisitor() {
+        World world = mock(World.class);
+        Player player = mock(Player.class);
+        doReturn(world).when(player).getWorld();
+
+        PlayerDeathEvent event = mock(PlayerDeathEvent.class);
+        doReturn(player).when(event).getEntity();
+
+        doReturn(true).when(worldManager).isSkyAssociatedWorld(world);
+        doReturn(false).when(plugin).playerIsOnIsland(player);
+        doReturn(false).when(plugin).playerIsInSpawn(player);
+
+        itemDropEvents.onDeathEvent(event);
+
+        verify(event).setKeepInventory(true);
+        verify(event, never()).getDrops();
+    }
+
+    @Test
+    public void pickupIsBlockedWhenVisitorTakesForeignLoot() {
+        World world = mock(World.class);
+        Player player = mock(Player.class);
+        doReturn(world).when(player).getWorld();
+        doReturn("Notch").when(player).getName();
+
+        // Loot tagged as belonging to someone else.
+        String foreignTag = I18nUtil.trLegacy("Owner: <player>", unparsed("player", "Herobrine"));
+        ItemMeta meta = mock(ItemMeta.class);
+        doReturn(new ArrayList<>(List.of(foreignTag))).when(meta).getLore();
+        ItemStack stack = mock(ItemStack.class);
+        doReturn(meta).when(stack).getItemMeta();
+        Item itemEntity = mock(Item.class);
+        doReturn(stack).when(itemEntity).getItemStack();
+
+        EntityPickupItemEvent event = mock(EntityPickupItemEvent.class);
+        doReturn(player).when(event).getEntity();
+        doReturn(false).when(event).isCancelled();
+        doReturn(itemEntity).when(event).getItem();
+
+        doReturn(true).when(worldManager).isSkyAssociatedWorld(world);
+        doReturn(false).when(plugin).playerIsOnIsland(player);
+        doReturn(false).when(plugin).playerIsInSpawn(player);
+
+        itemDropEvents.onPickupEvent(event);
+
+        verify(event).setCancelled(true);
+        verify(plugin).notifyPlayer(eq(player), any());
+    }
+
+    @Test
+    public void pickupAllowsOwnerToReclaimOwnLootAndClearsTag() {
+        World world = mock(World.class);
+        Player player = mock(Player.class);
+        doReturn(world).when(player).getWorld();
+        doReturn("Notch").when(player).getName();
+
+        // Loot tagged as belonging to this player (round-trip from a previous drop).
+        String ownerTag = I18nUtil.trLegacy("Owner: <player>", unparsed("player", "Notch"));
+        ItemMeta meta = mock(ItemMeta.class);
+        doReturn(new ArrayList<>(List.of(ownerTag))).when(meta).getLore();
+        ItemStack stack = mock(ItemStack.class);
+        doReturn(meta).when(stack).getItemMeta();
+        Item itemEntity = mock(Item.class);
+        doReturn(stack).when(itemEntity).getItemStack();
+
+        EntityPickupItemEvent event = mock(EntityPickupItemEvent.class);
+        doReturn(player).when(event).getEntity();
+        doReturn(false).when(event).isCancelled();
+        doReturn(itemEntity).when(event).getItem();
+
+        doReturn(true).when(worldManager).isSkyAssociatedWorld(world);
+
+        itemDropEvents.onPickupEvent(event);
+
+        // Owner recognised: pickup is allowed and the ownership tag is stripped.
+        verify(event, never()).setCancelled(true);
+        verify(stack).setItemMeta(meta);
+        verify(itemEntity).setItemStack(stack);
+
+        ArgumentCaptor<List> loreCaptor = ArgumentCaptor.forClass(List.class);
+        verify(meta).setLore(loreCaptor.capture());
+        assertTrue(loreCaptor.getValue().isEmpty());
+    }
+
+    private RuntimeConfigs runtimeConfigs(boolean visitorItemDrops) {
+        YamlConfiguration config = new YamlConfiguration();
+        config.setDefaults(PluginConfigLoader.loadBundledConfig());
+        config.set("options.protection.visitors.item-drops", visitorItemDrops);
+        RuntimeConfig runtimeConfig = new RuntimeConfigFactory(new GameObjectFactory(), Logger.getAnonymousLogger()).load(config);
+        RuntimeConfigs runtimeConfigs = mock(RuntimeConfigs.class);
+        doReturn(runtimeConfig).when(runtimeConfigs).current();
+        return runtimeConfigs;
+    }
+}

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/event/PlayerEventsProtectionTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/event/PlayerEventsProtectionTest.java
@@ -1,0 +1,256 @@
+package us.talabrek.ultimateskyblock.event;
+
+import dk.lockfuglsang.minecraft.util.BukkitServerMock;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.Levelled;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityChangeBlockEvent;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import us.talabrek.ultimateskyblock.config.PluginConfigLoader;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfig;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigFactory;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigs;
+import us.talabrek.ultimateskyblock.gameobject.GameObjectFactory;
+import us.talabrek.ultimateskyblock.island.IslandInfo;
+import us.talabrek.ultimateskyblock.uSkyBlock;
+import us.talabrek.ultimateskyblock.world.WorldManager;
+
+import java.util.logging.Logger;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit coverage for the mockable protection branches of {@link PlayerEvents}.
+ *
+ * <p>The banned / locked teleport branch ({@code onTeleport}) is intentionally not covered here: it resolves the
+ * target island through {@code WorldGuardHandler.getIslandNameAt}, which is a static call into WorldGuard (compileOnly,
+ * not on the test classpath). That path is left to the live-server harness.
+ */
+public class PlayerEventsProtectionTest {
+    private uSkyBlock plugin;
+    private WorldManager worldManager;
+    private RuntimeConfigs runtimeConfigs;
+    private PlayerEvents listener;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        BukkitServerMock.setupServerMock();
+        plugin = mock(uSkyBlock.class);
+        worldManager = mock(WorldManager.class);
+        when(plugin.getWorldManager()).thenReturn(worldManager);
+        when(worldManager.isSkyAssociatedWorld(any())).thenReturn(true);
+        runtimeConfigs = mock(RuntimeConfigs.class);
+        listener = new PlayerEvents(plugin, runtimeConfigs);
+    }
+
+    @Test
+    public void onVisitorDamage_cancelsFireDamageForVisitor() {
+        useConfig(true, true, false, false, false, "deny");
+        Player player = mock(Player.class);
+        when(player.getWorld()).thenReturn(mock(World.class));
+        when(plugin.playerIsOnIsland(player)).thenReturn(false);
+
+        EntityDamageEvent event = mock(EntityDamageEvent.class);
+        when(event.getEntity()).thenReturn(player);
+        when(event.getCause()).thenReturn(EntityDamageEvent.DamageCause.LAVA);
+        when(event.getDamage()).thenReturn(6.0);
+
+        listener.onVisitorDamage(event);
+
+        verify(event).setDamage(-6.0);
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    public void onVisitorDamage_cancelsFallDamageForVisitor() {
+        useConfig(true, false, true, false, false, "deny");
+        Player player = mock(Player.class);
+        when(player.getWorld()).thenReturn(mock(World.class));
+        when(plugin.playerIsOnIsland(player)).thenReturn(false);
+
+        EntityDamageEvent event = mock(EntityDamageEvent.class);
+        when(event.getEntity()).thenReturn(player);
+        when(event.getCause()).thenReturn(EntityDamageEvent.DamageCause.FALL);
+        when(event.getDamage()).thenReturn(3.0);
+
+        listener.onVisitorDamage(event);
+
+        verify(event).setDamage(-3.0);
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    public void onVisitorDamage_ignoresPlayerOnOwnIsland() {
+        useConfig(true, true, true, false, false, "deny");
+        Player player = mock(Player.class);
+        when(player.getWorld()).thenReturn(mock(World.class));
+        when(plugin.playerIsOnIsland(player)).thenReturn(true);
+
+        EntityDamageEvent event = mock(EntityDamageEvent.class);
+        when(event.getEntity()).thenReturn(player);
+
+        listener.onVisitorDamage(event);
+
+        verify(event, never()).setCancelled(true);
+    }
+
+    @Test
+    public void onVisitorDamageByEntity_cancelsMonsterDamageForVisitor() {
+        useConfig(true, false, false, true, false, "deny");
+        Player player = mock(Player.class);
+        when(player.getWorld()).thenReturn(mock(World.class));
+        when(plugin.playerIsOnIsland(player)).thenReturn(false);
+        Entity damager = mock(Entity.class);
+
+        EntityDamageByEntityEvent event = mock(EntityDamageByEntityEvent.class);
+        when(event.getEntity()).thenReturn(player);
+        when(event.getDamager()).thenReturn(damager);
+        when(event.getCause()).thenReturn(EntityDamageEvent.DamageCause.ENTITY_ATTACK);
+        when(event.getDamage()).thenReturn(4.0);
+
+        listener.onVisitorDamageByEntity(event);
+
+        verify(event).setDamage(-4.0);
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    public void onVisitorDamageByEntity_allowsPlayerPvPWhenPvPEnabled() {
+        useConfig(true, false, false, true, false, "allow");
+        Player victim = mock(Player.class);
+        when(victim.getWorld()).thenReturn(mock(World.class));
+        when(plugin.playerIsOnIsland(victim)).thenReturn(false);
+        Player attacker = mock(Player.class);
+
+        EntityDamageByEntityEvent event = mock(EntityDamageByEntityEvent.class);
+        when(event.getEntity()).thenReturn(victim);
+        when(event.getDamager()).thenReturn(attacker);
+        when(event.getCause()).thenReturn(EntityDamageEvent.DamageCause.ENTITY_ATTACK);
+
+        listener.onVisitorDamageByEntity(event);
+
+        verify(event, never()).setCancelled(true);
+    }
+
+    @Test
+    public void onMemberDamage_cancelsPvPBetweenSameIslandMembers() {
+        useConfig(true, false, false, false, false, "allow");
+        Player victim = mock(Player.class);
+        when(victim.getWorld()).thenReturn(mock(World.class));
+        Player attacker = mock(Player.class);
+
+        EntityDamageByEntityEvent event = mock(EntityDamageByEntityEvent.class);
+        when(event.getEntity()).thenReturn(victim);
+        when(event.getDamager()).thenReturn(attacker);
+
+        IslandInfo island = mock(IslandInfo.class);
+        when(island.getName()).thenReturn("island-alpha");
+        when(plugin.getIslandInfo(attacker)).thenReturn(island);
+        when(plugin.getIslandInfo(victim)).thenReturn(island);
+
+        listener.onMemberDamage(event);
+
+        verify(event).setCancelled(true);
+        verify(plugin).notifyPlayer(eq(attacker), any());
+    }
+
+    @Test
+    public void onMemberDamage_allowsPvPBetweenDifferentIslands() {
+        useConfig(true, false, false, false, false, "allow");
+        Player victim = mock(Player.class);
+        when(victim.getWorld()).thenReturn(mock(World.class));
+        Player attacker = mock(Player.class);
+
+        EntityDamageByEntityEvent event = mock(EntityDamageByEntityEvent.class);
+        when(event.getEntity()).thenReturn(victim);
+        when(event.getDamager()).thenReturn(attacker);
+
+        IslandInfo attackerIsland = mock(IslandInfo.class);
+        when(attackerIsland.getName()).thenReturn("island-alpha");
+        IslandInfo victimIsland = mock(IslandInfo.class);
+        when(victimIsland.getName()).thenReturn("island-beta");
+        when(plugin.getIslandInfo(attacker)).thenReturn(attackerIsland);
+        when(plugin.getIslandInfo(victim)).thenReturn(victimIsland);
+
+        listener.onMemberDamage(event);
+
+        verify(event, never()).setCancelled(true);
+    }
+
+    @Test
+    public void onLavaReplace_cancelsReplacingLavaSource() {
+        useConfig(true, false, false, false, true, "deny");
+        Player player = mock(Player.class);
+        when(player.getWorld()).thenReturn(mock(World.class));
+
+        Levelled lava = lavaSource();
+        BlockState replaced = mock(BlockState.class);
+        when(replaced.getBlockData()).thenReturn(lava);
+
+        BlockPlaceEvent event = mock(BlockPlaceEvent.class);
+        when(event.getPlayer()).thenReturn(player);
+        when(event.getBlockReplacedState()).thenReturn(replaced);
+
+        listener.onLavaReplace(event);
+
+        verify(event).setCancelled(true);
+    }
+
+    @Test
+    public void onLavaAbsorption_cancelsEntityConsumingLavaSource() {
+        useConfig(true, false, false, false, true, "deny");
+        World world = mock(World.class);
+        Block block = mock(Block.class);
+        when(block.getWorld()).thenReturn(world);
+        when(block.getLocation()).thenReturn(new Location(world, 0, 0, 0));
+        Levelled lava = lavaSource();
+        when(block.getBlockData()).thenReturn(lava);
+
+        EntityChangeBlockEvent event = mock(EntityChangeBlockEvent.class);
+        when(event.getBlock()).thenReturn(block);
+        when(event.getTo()).thenReturn(Material.COBBLESTONE);
+
+        listener.onLavaAbsorption(event);
+
+        verify(event).setCancelled(true);
+        verify(world).dropItemNaturally(any(Location.class), any(ItemStack.class));
+    }
+
+    private Levelled lavaSource() {
+        Levelled lava = mock(Levelled.class);
+        when(lava.getMaterial()).thenReturn(Material.LAVA);
+        when(lava.getLevel()).thenReturn(0);
+        return lava;
+    }
+
+    private void useConfig(boolean protectionEnabled, boolean fireDamage, boolean fallDamage,
+                           boolean monsterDamage, boolean protectLava, String allowPvP) {
+        YamlConfiguration config = new YamlConfiguration();
+        config.setDefaults(PluginConfigLoader.loadBundledConfig());
+        config.set("options.protection.enabled", protectionEnabled);
+        config.set("options.protection.visitors.fire-damage", fireDamage);
+        config.set("options.protection.visitors.fall", fallDamage);
+        config.set("options.protection.visitors.monster-damage", monsterDamage);
+        config.set("options.protection.protect-lava", protectLava);
+        config.set("options.island.allowPvP", allowPvP);
+        RuntimeConfig runtimeConfig = new RuntimeConfigFactory(new GameObjectFactory(), Logger.getAnonymousLogger()).load(config);
+        doReturn(runtimeConfig).when(runtimeConfigs).current();
+    }
+}

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/event/PortalEventsTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/event/PortalEventsTest.java
@@ -1,0 +1,174 @@
+package us.talabrek.ultimateskyblock.event;
+
+import dk.lockfuglsang.minecraft.util.BukkitServerMock;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.event.entity.EntityPortalEvent;
+import org.bukkit.event.player.PlayerPortalEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import us.talabrek.ultimateskyblock.island.IslandInfo;
+import us.talabrek.ultimateskyblock.config.PluginConfigLoader;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfig;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigFactory;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigs;
+import us.talabrek.ultimateskyblock.gameobject.GameObjectFactory;
+import us.talabrek.ultimateskyblock.uSkyBlock;
+import us.talabrek.ultimateskyblock.world.WorldManager;
+
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class PortalEventsTest {
+    private uSkyBlock plugin;
+    private WorldManager worldManager;
+    private PortalEvents portalEvents;
+    private int radius;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        BukkitServerMock.setupServerMock();
+        plugin = mock(uSkyBlock.class);
+        worldManager = mock(WorldManager.class);
+
+        YamlConfiguration config = new YamlConfiguration();
+        config.setDefaults(PluginConfigLoader.loadBundledConfig());
+        config.set("options.island.distance", 110);
+        config.set("options.island.protectionRange", 100);
+        RuntimeConfig runtimeConfig = new RuntimeConfigFactory(new GameObjectFactory(), Logger.getAnonymousLogger()).load(config);
+        radius = runtimeConfig.island().radius(); // protectionRange / 2 == 50
+
+        RuntimeConfigs runtimeConfigs = mock(RuntimeConfigs.class);
+        doReturn(runtimeConfig).when(runtimeConfigs).current();
+
+        portalEvents = new PortalEvents(plugin, worldManager, runtimeConfigs);
+    }
+
+    @Test
+    public void playerPortalOverworldToNetherRetargetsToIslandLocation() {
+        World overworld = mock(World.class);
+        World nether = mock(World.class);
+        Location from = new Location(overworld, 100, 64, 200);
+        Location islandLocation = new Location(overworld, 12, 70, 34);
+
+        PlayerPortalEvent event = mock(PlayerPortalEvent.class);
+        doReturn(PlayerTeleportEvent.TeleportCause.NETHER_PORTAL).when(event).getCause();
+        doReturn(from).when(event).getFrom();
+        doReturn(true).when(worldManager).isSkyWorld(overworld);
+        doReturn(nether).when(worldManager).getNetherWorld();
+
+        IslandInfo islandInfo = mock(IslandInfo.class);
+        doReturn(islandInfo).when(plugin).getIslandInfo(from);
+        doReturn(islandLocation).when(islandInfo).getIslandLocation();
+
+        portalEvents.onPlayerPortal(event);
+
+        ArgumentCaptor<Location> toCaptor = ArgumentCaptor.forClass(Location.class);
+        verify(event).setTo(toCaptor.capture());
+        Location to = toCaptor.getValue();
+        assertEquals(nether, to.getWorld());
+        assertEquals(12, to.getBlockX());
+        assertEquals(70, to.getBlockY());
+        assertEquals(34, to.getBlockZ());
+
+        verify(event).setSearchRadius(radius);
+        verify(event).setCanCreatePortal(true);
+        verify(event).setCreationRadius(Math.max(1, radius - 4));
+    }
+
+    @Test
+    public void playerPortalNetherToOverworldFallsBackToFromWhenNoIsland() {
+        World nether = mock(World.class);
+        World overworld = mock(World.class);
+        Location from = new Location(nether, -5, 40, 7);
+
+        PlayerPortalEvent event = mock(PlayerPortalEvent.class);
+        doReturn(PlayerTeleportEvent.TeleportCause.NETHER_PORTAL).when(event).getCause();
+        doReturn(from).when(event).getFrom();
+        doReturn(false).when(worldManager).isSkyWorld(nether);
+        doReturn(true).when(worldManager).isSkyNether(nether);
+        doReturn(overworld).when(worldManager).getWorld();
+        doReturn(null).when(plugin).getIslandInfo(from);
+
+        portalEvents.onPlayerPortal(event);
+
+        ArgumentCaptor<Location> toCaptor = ArgumentCaptor.forClass(Location.class);
+        verify(event).setTo(toCaptor.capture());
+        Location to = toCaptor.getValue();
+        assertEquals(overworld, to.getWorld());
+        assertEquals(-5, to.getBlockX());
+        assertEquals(40, to.getBlockY());
+        assertEquals(7, to.getBlockZ());
+
+        verify(event).setSearchRadius(radius);
+        verify(event).setCanCreatePortal(true);
+        verify(event).setCreationRadius(Math.max(1, radius - 4));
+    }
+
+    @Test
+    public void playerPortalIgnoresNonNetherPortalCause() {
+        PlayerPortalEvent event = mock(PlayerPortalEvent.class);
+        doReturn(PlayerTeleportEvent.TeleportCause.END_PORTAL).when(event).getCause();
+
+        portalEvents.onPlayerPortal(event);
+
+        verify(event, never()).setTo(any());
+        verify(event, never()).setSearchRadius(anyInt());
+        verify(event, never()).setCanCreatePortal(anyBoolean());
+        verify(event, never()).setCreationRadius(anyInt());
+    }
+
+    @Test
+    public void playerPortalIgnoresWorldOutsideSkyblock() {
+        World other = mock(World.class);
+        Location from = new Location(other, 0, 64, 0);
+
+        PlayerPortalEvent event = mock(PlayerPortalEvent.class);
+        doReturn(PlayerTeleportEvent.TeleportCause.NETHER_PORTAL).when(event).getCause();
+        doReturn(from).when(event).getFrom();
+        doReturn(false).when(worldManager).isSkyWorld(other);
+        doReturn(false).when(worldManager).isSkyNether(other);
+
+        portalEvents.onPlayerPortal(event);
+
+        verify(event, never()).setTo(any());
+        verify(event, never()).setSearchRadius(anyInt());
+        verify(event, never()).setCanCreatePortal(anyBoolean());
+    }
+
+    @Test
+    public void entityPortalOverworldToNetherRetargetsButCannotCreatePortal() {
+        World overworld = mock(World.class);
+        World nether = mock(World.class);
+        Location from = new Location(overworld, 8, 60, 9);
+        Location islandLocation = new Location(overworld, 1, 65, 2);
+
+        EntityPortalEvent event = mock(EntityPortalEvent.class);
+        doReturn(from).when(event).getFrom();
+        doReturn(true).when(worldManager).isSkyWorld(overworld);
+        doReturn(nether).when(worldManager).getNetherWorld();
+
+        IslandInfo islandInfo = mock(IslandInfo.class);
+        doReturn(islandInfo).when(plugin).getIslandInfo(from);
+        doReturn(islandLocation).when(islandInfo).getIslandLocation();
+
+        portalEvents.onEntityPortal(event);
+
+        ArgumentCaptor<Location> toCaptor = ArgumentCaptor.forClass(Location.class);
+        verify(event).setTo(toCaptor.capture());
+        Location to = toCaptor.getValue();
+        assertEquals(nether, to.getWorld());
+        assertEquals(1, to.getBlockX());
+        assertEquals(65, to.getBlockY());
+        assertEquals(2, to.getBlockZ());
+
+        verify(event).setSearchRadius(radius);
+        verify(event).setCanCreatePortal(false);
+        verify(event).setCreationRadius(Math.max(1, radius - 4));
+    }
+}

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/event/SpawnEventsTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/event/SpawnEventsTest.java
@@ -1,0 +1,97 @@
+package us.talabrek.ultimateskyblock.event;
+
+import dk.lockfuglsang.minecraft.po.I18nUtil;
+import dk.lockfuglsang.minecraft.util.BukkitServerMock;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.CreatureSpawnEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SpawnEggMeta;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import us.talabrek.ultimateskyblock.island.IslandLogic;
+import us.talabrek.ultimateskyblock.island.LimitLogic;
+import us.talabrek.ultimateskyblock.player.PlayerNotifier;
+import us.talabrek.ultimateskyblock.uSkyBlock;
+import us.talabrek.ultimateskyblock.world.WorldManager;
+
+import java.io.File;
+import java.util.Locale;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests for {@link SpawnEvents} covering only the branches reachable without WorldGuard.
+ * The {@code checkLimits(...)} spawn-limit path relies on {@code WorldGuardHandler.getIslandNameAt(...)}
+ * (WorldGuard is compileOnly and off the test classpath), so those branches are left to the live-server harness.
+ */
+public class SpawnEventsTest {
+    private uSkyBlock plugin;
+    private WorldManager worldManager;
+    private PlayerNotifier notifier;
+    private SpawnEvents spawnEvents;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        BukkitServerMock.setupServerMock();
+        I18nUtil.initialize(new File("."), Locale.ENGLISH);
+
+        plugin = mock(uSkyBlock.class);
+        worldManager = mock(WorldManager.class);
+        notifier = mock(PlayerNotifier.class);
+        spawnEvents = new SpawnEvents(plugin, worldManager, mock(LimitLogic.class), mock(IslandLogic.class), notifier);
+    }
+
+    @Test
+    public void spawnEggDeniedWhenVisitorOffIsland() {
+        Player player = mock(Player.class);
+        when(player.getWorld()).thenReturn(mock(World.class));
+        when(worldManager.isSkyAssociatedWorld(any())).thenReturn(true);
+        when(plugin.playerIsOnIsland(player)).thenReturn(false);
+
+        ItemStack item = mock(ItemStack.class);
+        when(item.getItemMeta()).thenReturn(mock(SpawnEggMeta.class));
+
+        PlayerInteractEvent event = mock(PlayerInteractEvent.class);
+        when(event.getPlayer()).thenReturn(player);
+        when(event.useItemInHand()).thenReturn(Event.Result.ALLOW);
+        when(event.getAction()).thenReturn(Action.RIGHT_CLICK_AIR);
+        when(event.getItem()).thenReturn(item);
+
+        spawnEvents.onSpawnEggEvent(event);
+
+        verify(event).setCancelled(true);
+        verify(notifier).notifyPlayer(eq(player), any());
+    }
+
+    @Test
+    public void creatureSpawnAllowedForSpawnerEgg() {
+        World world = mock(World.class);
+        when(worldManager.isSkyAssociatedWorld(world)).thenReturn(true);
+
+        CreatureSpawnEvent event = mock(CreatureSpawnEvent.class);
+        when(event.getLocation()).thenReturn(new Location(world, 0, 0, 0));
+        when(event.getSpawnReason()).thenReturn(CreatureSpawnEvent.SpawnReason.SPAWNER_EGG);
+
+        spawnEvents.onCreatureSpawn(event);
+
+        verify(event, never()).setCancelled(anyBoolean());
+    }
+
+    @Test
+    public void creatureSpawnIgnoredOutsideSkyworld() {
+        World world = mock(World.class);
+        when(worldManager.isSkyAssociatedWorld(any())).thenReturn(false);
+
+        CreatureSpawnEvent event = mock(CreatureSpawnEvent.class);
+        when(event.getLocation()).thenReturn(new Location(world, 0, 0, 0));
+
+        spawnEvents.onCreatureSpawn(event);
+
+        verify(event, never()).setCancelled(anyBoolean());
+    }
+}


### PR DESCRIPTION
Round-2 series, part 3: fast, version-agnostic **unit** tests for the protection subsystem — listener cancel-decisions and bootstrap registration gating. No live harness needed.

## Coverage (7 classes, 51 tests)
- **ListenersRegistrationTest** — each protection listener registers iff its config flag is on (`protection.enabled` → grief; `item-drops`; `spawn-limits.enabled`; `block-banned-entry` → worldGuardEvents; `tool-menu.enabled`), and the always-on listeners register unconditionally. Guards against a whole protection subsystem silently disabling.
- **GriefEventsProtectionTest** — creeper/TNT explosion suppression, visitor shear, farmland trampling, egg-hatch, kill-animal/monster cancels.
- **ExploitEventsTest** — portal-use + vehicle enter/damage/destroy visitor cancels.
- **SpawnEventsTest** — off-island spawn-egg denial, spawner-egg / non-sky bypass.
- **PortalEventsTest** — nether↔overworld retargeting, search/creation radius, can-create-portal (player vs entity).
- **ItemDropEventsTest** — lore-tag drop ownership, visitor drop/pickup blocking, keep-inventory on death.
- **PlayerEventsProtectionTest** — visitor fall/fire/monster damage immunity + PvP exception, same-island member-PvP cancel, lava-source protection.

## Non-brittle by design
Follows the `InternalEventsTest` idiom (mocked `uSkyBlock` + a **real** `RuntimeConfig` via `RuntimeConfigFactory`, since records can't be mocked; `doReturn().when()` throughout). Branches that require WorldGuard statics (wither rampage, banned/locked entry, spawn over-limit) or that initialize Bukkit's `Registry` (villager-trade `InventoryType.MERCHANT`) are **intentionally left to the live harness** rather than forced through `mockStatic` — no brittle global-state hacks.

## Validation
`./gradlew :uSkyBlock-Core:test` — BUILD SUCCESSFUL, 315 tests, 0 failures.

> Note: committed with `--no-gpg-sign` (the 1Password SSH signing agent was locked). Re-sign on merge if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)