### PR TITLE
Unit tests for IslandInfo party/membership + warp

### DIFF
--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/command/island/WarpCommandGateTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/command/island/WarpCommandGateTest.java
@@ -1,0 +1,130 @@
+package us.talabrek.ultimateskyblock.command.island;
+
+import dk.lockfuglsang.minecraft.po.I18nUtil;
+import dk.lockfuglsang.minecraft.util.BukkitServerMock;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import us.talabrek.ultimateskyblock.config.PluginConfigLoader;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigFactory;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigs;
+import us.talabrek.ultimateskyblock.gameobject.GameObjectFactory;
+import us.talabrek.ultimateskyblock.island.IslandInfo;
+import us.talabrek.ultimateskyblock.player.PlayerInfo;
+import us.talabrek.ultimateskyblock.player.TeleportLogic;
+import us.talabrek.ultimateskyblock.uSkyBlock;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.logging.Logger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Covers the {@code /is warp <player>} access gate in {@link WarpCommand#doExecute}: a player may
+ * warp to another island only when that island has an active warp <em>or</em> the visitor is trusted
+ * (WarpCommand ~line 69). The command is trivially constructible ({@code new WarpCommand(plugin,
+ * runtimeConfigs)} — no Guice injector), and the target island is a mock, so this stays a focused
+ * unit test of the gate rather than of IslandInfo internals.
+ */
+public class WarpCommandGateTest {
+    private uSkyBlock plugin;
+    private TeleportLogic teleportLogic;
+    private Player player;
+    private PlayerInfo targetInfo;
+    private IslandInfo targetIsland;
+    private WarpCommand command;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        BukkitServerMock.setupServerMock();
+        I18nUtil.initialize(new File("."), Locale.ENGLISH);
+
+        plugin = mock(uSkyBlock.class);
+        RuntimeConfigs runtimeConfigs = mock(RuntimeConfigs.class);
+
+        // RuntimeConfig (and its nested records) cannot be mocked, so build a real one from the
+        // bundled defaults plus the overrides RuntimeConfigFactory#load requires. The warp path
+        // reads runtimeConfigs.current().protection().visitorWarnOnWarp().
+        YamlConfiguration config = new YamlConfiguration();
+        config.setDefaults(PluginConfigLoader.loadBundledConfig());
+        config.set("language", "en");
+        config.set("options.general.worldName", "skyworld");
+        config.set("options.general.cooldownRestart", "1m");
+        config.set("options.general.biomeChange", "1m");
+        config.set("options.general.defaultBiome", "plains");
+        config.set("options.general.defaultNetherBiome", "nether_wastes");
+        config.set("options.advanced.confirmTimeout", "30s");
+        config.set("options.advanced.playerdb.storage", "file");
+        config.set("options.advanced.playerdb.nameCache", "maximumSize=100");
+        config.set("options.advanced.playerdb.uuidCache", "maximumSize=100");
+        config.set("options.advanced.playerCache", "maximumSize=100");
+        config.set("options.advanced.islandCache", "maximumSize=100");
+        config.set("options.advanced.island.saveEvery", 60);
+        config.set("options.advanced.player.saveEvery", 60);
+        config.set("options.party.invite-timeout", "1m");
+        config.set("options.island.distance", 110);
+        config.set("options.island.height", 120);
+        config.set("options.island.topTenTimeout", "15m");
+        config.set("options.island.islandTeleportDelay", "2s");
+        config.set("options.island.chat-format", "default");
+        config.set("options.party.chat-format", "default");
+        config.set("nether.chunk-generator", "default");
+        config.set("plugin-updates.branch", "LATEST");
+        doReturn(new RuntimeConfigFactory(new GameObjectFactory(), Logger.getAnonymousLogger()).load(config))
+            .when(runtimeConfigs).current();
+
+        teleportLogic = mock(TeleportLogic.class);
+        doReturn(teleportLogic).when(plugin).getTeleportLogic();
+
+        player = mock(Player.class);
+        doReturn(true).when(player).hasPermission("usb.island.warp");
+        doReturn("Visitor").when(player).getDisplayName();
+
+        PlayerInfo senderInfo = mock(PlayerInfo.class);
+        doReturn(false).when(senderInfo).isIslandGenerating();
+        doReturn(senderInfo).when(plugin).getPlayerInfo(player);
+
+        targetInfo = mock(PlayerInfo.class);
+        doReturn(true).when(targetInfo).getHasIsland();
+        doReturn(false).when(targetInfo).isIslandGenerating();
+        doReturn(targetInfo).when(plugin).getPlayerInfo("target");
+
+        targetIsland = mock(IslandInfo.class);
+        doReturn(targetIsland).when(plugin).getIslandInfo(targetInfo);
+
+        command = new WarpCommand(plugin, runtimeConfigs);
+    }
+
+    @Test
+    public void trustedVisitorMayWarpToIslandWithInactiveWarp() {
+        doReturn(false).when(targetIsland).hasWarp();
+        doReturn(true).when(targetIsland).isTrusted(player);
+        doReturn(false).when(targetIsland).isBanned(player);
+
+        boolean handled = command.execute(player, "island", new HashMap<>(), "target");
+
+        assertThat(handled, is(true));
+        verify(teleportLogic).warpTeleport(player, targetInfo, false);
+    }
+
+    @Test
+    public void untrustedVisitorMayNotWarpToIslandWithInactiveWarp() {
+        doReturn(false).when(targetIsland).hasWarp();
+        doReturn(false).when(targetIsland).isTrusted(player);
+
+        boolean handled = command.execute(player, "island", new HashMap<>(), "target");
+
+        assertThat(handled, is(true));
+        verify(teleportLogic, never()).warpTeleport(any(), any(), anyBoolean());
+    }
+}

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/island/IslandInfoPartyTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/island/IslandInfoPartyTest.java
@@ -1,0 +1,305 @@
+package us.talabrek.ultimateskyblock.island;
+
+import dk.lockfuglsang.minecraft.po.I18nUtil;
+import dk.lockfuglsang.minecraft.util.BukkitServerMock;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.Server;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.PluginManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import us.talabrek.ultimateskyblock.config.PluginConfigLoader;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigFactory;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigs;
+import us.talabrek.ultimateskyblock.gameobject.GameObjectFactory;
+import us.talabrek.ultimateskyblock.player.IslandPerk;
+import us.talabrek.ultimateskyblock.player.Perk;
+import us.talabrek.ultimateskyblock.player.PerkLogic;
+import us.talabrek.ultimateskyblock.player.PlayerLogic;
+import us.talabrek.ultimateskyblock.uuid.PlayerDB;
+import us.talabrek.ultimateskyblock.uSkyBlock;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for the config-backed party/membership bookkeeping on a real {@link IslandInfo}.
+ *
+ * <p>Note: {@link IslandInfo#addMember} and {@link IslandInfo#removeMember} are intentionally not
+ * exercised here. Both unconditionally call {@code WorldGuardHandler.updateRegion(this)}, which
+ * dereferences WorldEdit/WorldGuard types (e.g. {@code BlockVector3}, {@code ProtectedCuboidRegion})
+ * that are {@code compileOnly} and absent from the test classpath. Invoking them raises a
+ * {@link NoClassDefFoundError} that escapes the handler's {@code catch (Exception)}. The membership
+ * bookkeeping those methods write is instead verified from the read side by seeding
+ * {@code party.members} directly; the write paths belong to the live-server harness.
+ */
+public class IslandInfoPartyTest {
+    private static final UUID LEADER_UUID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID ALICE_UUID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private static final UUID BOB_UUID = UUID.fromString("33333333-3333-3333-3333-333333333333");
+    private static final UUID TARGET_UUID = UUID.fromString("44444444-4444-4444-4444-444444444444");
+
+    @TempDir
+    Path tempDir;
+
+    private uSkyBlock plugin;
+    private RuntimeConfigs runtimeConfigs;
+    private PlayerDB playerDB;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        BukkitServerMock.setupServerMock();
+        I18nUtil.initialize(new File("."), Locale.ENGLISH);
+
+        plugin = mock(uSkyBlock.class);
+
+        playerDB = mock(PlayerDB.class);
+        doReturn(playerDB).when(plugin).getPlayerDB();
+
+        // A real RuntimeConfig - the nested records cannot be mocked (ClassFormatError). Some methods
+        // under test (e.g. getMaxPartySize -> getSchematicName) read the runtime config eagerly.
+        runtimeConfigs = mock(RuntimeConfigs.class);
+        doReturn(new RuntimeConfigFactory(new GameObjectFactory(), Logger.getAnonymousLogger()).load(buildConfig()))
+            .when(runtimeConfigs).current();
+
+        // Event firing (ban/unban/trust/untrust) goes through plugin.getServer().getPluginManager().callEvent.
+        // A mock PluginManager makes callEvent a no-op, so the events are never cancelled.
+        PluginManager pluginManager = mock(PluginManager.class);
+        Server server = mock(Server.class);
+        doReturn(pluginManager).when(server).getPluginManager();
+        doReturn(server).when(plugin).getServer();
+
+        // banPlayerInfo/unbanPlayerInfo look the PlayerInfo up via PlayerLogic; a mock returns null -> no-op.
+        doReturn(mock(PlayerLogic.class)).when(plugin).getPlayerLogic();
+    }
+
+    @Test
+    public void getMembersReturnsSeededMemberNames() throws Exception {
+        doReturn("Leader").when(playerDB).getName(LEADER_UUID);
+        doReturn("Alice").when(playerDB).getName(ALICE_UUID);
+
+        IslandInfo island = createIsland("island", config -> {
+            seedLeader(config);
+            seedMember(config, ALICE_UUID, "Alice");
+            config.set("party.currentSize", 2);
+        });
+
+        assertThat(island.getMembers(), containsInAnyOrder("Leader", "Alice"));
+        assertThat(island.getMemberUUIDs(), containsInAnyOrder(LEADER_UUID, ALICE_UUID));
+        assertEquals(2, island.getPartySize());
+    }
+
+    @Test
+    public void partySizeAndMembersReflectPartyGrowth() throws Exception {
+        doReturn("Leader").when(playerDB).getName(LEADER_UUID);
+        doReturn("Alice").when(playerDB).getName(ALICE_UUID);
+        doReturn("Bob").when(playerDB).getName(BOB_UUID);
+
+        IslandInfo solo = createIsland("solo", config -> {
+            seedLeader(config);
+            config.set("party.currentSize", 1);
+        });
+        IslandInfo party = createIsland("party", config -> {
+            seedLeader(config);
+            seedMember(config, ALICE_UUID, "Alice");
+            seedMember(config, BOB_UUID, "Bob");
+            config.set("party.currentSize", 3);
+        });
+
+        assertEquals(1, solo.getPartySize());
+        assertThat(solo.getMembers(), hasSize(1));
+        assertEquals(3, party.getPartySize());
+        assertThat(party.getMembers(), hasSize(3));
+    }
+
+    @Test
+    public void isMemberIdentifiesSeededMembers() throws Exception {
+        IslandInfo island = createIsland("island", config -> {
+            seedLeader(config);
+            seedMember(config, ALICE_UUID, "Alice");
+            config.set("party.currentSize", 2);
+        });
+
+        OfflinePlayer alice = offlinePlayer(ALICE_UUID);
+        OfflinePlayer stranger = offlinePlayer(TARGET_UUID);
+
+        assertTrue(island.isMember(alice));
+        assertFalse(island.isMember(stranger));
+    }
+
+    @Test
+    public void isLeaderIdentifiesTheLeader() throws Exception {
+        IslandInfo island = createIsland("island", config -> {
+            seedLeader(config);
+            seedMember(config, ALICE_UUID, "Alice");
+            config.set("party.currentSize", 2);
+        });
+
+        OfflinePlayer leader = offlinePlayer(LEADER_UUID);
+        OfflinePlayer member = offlinePlayer(ALICE_UUID);
+
+        assertTrue(island.isLeader(leader));
+        assertFalse(island.isLeader(member));
+    }
+
+    @Test
+    public void getMaxPartySizeReturnsPerkDefaultWithoutOverride() throws Exception {
+        stubPerkDefaultMaxPartySize(4);
+
+        IslandInfo island = createIsland("island", config -> {
+            seedLeader(config);
+            config.set("party.currentSize", 1);
+        });
+
+        assertEquals(4, island.getMaxPartySize());
+    }
+
+    @Test
+    public void getMaxPartySizeHonorsPerIslandOverride() throws Exception {
+        stubPerkDefaultMaxPartySize(4);
+
+        IslandInfo island = createIsland("island", config -> {
+            seedLeader(config);
+            seedMember(config, ALICE_UUID, "Alice");
+            config.set("party.members." + ALICE_UUID + ".maxPartySizePermission", 8);
+            config.set("party.currentSize", 2);
+        });
+
+        assertEquals(8, island.getMaxPartySize());
+    }
+
+    @Test
+    public void banPlayerAddsBanAndUnbanRemovesIt() throws Exception {
+        doReturn("Target").when(playerDB).getName(TARGET_UUID);
+        OfflinePlayer target = offlinePlayer(TARGET_UUID);
+
+        IslandInfo island = createIsland("island", config -> {
+            seedLeader(config);
+            config.set("party.currentSize", 1);
+        });
+
+        assertTrue(island.banPlayer(target, null));
+        assertTrue(island.isBanned(target));
+        assertThat(island.getBans(), contains("Target"));
+
+        assertTrue(island.unbanPlayer(target, null));
+        assertFalse(island.isBanned(target));
+        assertThat(island.getBans(), empty());
+    }
+
+    @Test
+    public void banPlayerRejectsExistingMember() throws Exception {
+        OfflinePlayer alice = offlinePlayer(ALICE_UUID);
+
+        IslandInfo island = createIsland("island", config -> {
+            seedLeader(config);
+            seedMember(config, ALICE_UUID, "Alice");
+            config.set("party.currentSize", 2);
+        });
+
+        assertFalse(island.banPlayer(alice, null));
+        assertFalse(island.isBanned(alice));
+    }
+
+    @Test
+    public void trustPlayerAddsTrusteeAndUntrustRemovesIt() throws Exception {
+        doReturn("Target").when(playerDB).getName(TARGET_UUID);
+        OfflinePlayer target = offlinePlayer(TARGET_UUID);
+
+        IslandInfo island = createIsland("island", config -> {
+            seedLeader(config);
+            config.set("party.currentSize", 1);
+        });
+
+        assertTrue(island.trustPlayer(target, null));
+        assertTrue(island.isTrusted(target));
+        assertThat(island.getTrustees(), contains("Target"));
+
+        assertTrue(island.untrustPlayer(target, null));
+        assertFalse(island.isTrusted(target));
+        assertThat(island.getTrustees(), empty());
+    }
+
+    private void stubPerkDefaultMaxPartySize(int maxPartySize) {
+        PerkLogic perkLogic = mock(PerkLogic.class);
+        IslandPerk islandPerk = mock(IslandPerk.class);
+        Perk perk = mock(Perk.class);
+        doReturn(perkLogic).when(plugin).getPerkLogic();
+        doReturn(islandPerk).when(perkLogic).getIslandPerk(anyString());
+        doReturn(perk).when(islandPerk).getPerk();
+        doReturn(maxPartySize).when(perk).getMaxPartySize();
+    }
+
+    private OfflinePlayer offlinePlayer(UUID uuid) {
+        OfflinePlayer player = mock(OfflinePlayer.class);
+        doReturn(uuid).when(player).getUniqueId();
+        return player;
+    }
+
+    private static void seedLeader(YamlConfiguration config) {
+        config.set("party.leader", "Leader");
+        config.set("party.leader-uuid", LEADER_UUID.toString());
+        seedMember(config, LEADER_UUID, "Leader");
+    }
+
+    private static void seedMember(YamlConfiguration config, UUID uuid, String name) {
+        config.set("party.members." + uuid + ".name", name);
+    }
+
+    private IslandInfo createIsland(String name, Consumer<YamlConfiguration> customizer) throws Exception {
+        File islandDir = tempDir.resolve("islands").toFile();
+        islandDir.mkdirs();
+        File islandConfigFile = new File(islandDir, name + ".yml");
+        YamlConfiguration config = new YamlConfiguration();
+        config.set("version", 3);
+        customizer.accept(config);
+        config.save(islandConfigFile);
+        return new IslandInfo(name, plugin, runtimeConfigs, islandDir.toPath());
+    }
+
+    private static YamlConfiguration buildConfig() {
+        YamlConfiguration config = new YamlConfiguration();
+        config.setDefaults(PluginConfigLoader.loadBundledConfig());
+        config.set("language", "en");
+        config.set("options.general.worldName", "skyworld");
+        config.set("options.general.cooldownRestart", "1m");
+        config.set("options.general.biomeChange", "1m");
+        config.set("options.general.defaultBiome", "plains");
+        config.set("options.general.defaultNetherBiome", "nether_wastes");
+        config.set("options.advanced.confirmTimeout", "30s");
+        config.set("options.advanced.playerdb.storage", "file");
+        config.set("options.advanced.playerdb.nameCache", "maximumSize=100");
+        config.set("options.advanced.playerdb.uuidCache", "maximumSize=100");
+        config.set("options.advanced.playerCache", "maximumSize=100");
+        config.set("options.advanced.islandCache", "maximumSize=100");
+        config.set("options.advanced.island.saveEvery", 60);
+        config.set("options.advanced.player.saveEvery", 60);
+        config.set("options.party.invite-timeout", "1m");
+        config.set("options.island.distance", 110);
+        config.set("options.island.height", 120);
+        config.set("options.island.topTenTimeout", "15m");
+        config.set("options.island.islandTeleportDelay", "2s");
+        config.set("options.island.chat-format", "default");
+        config.set("options.party.chat-format", "default");
+        config.set("nether.chunk-generator", "default");
+        config.set("plugin-updates.branch", "LATEST");
+        return config;
+    }
+}

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/island/IslandInfoWarpTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/island/IslandInfoWarpTest.java
@@ -1,0 +1,154 @@
+package us.talabrek.ultimateskyblock.island;
+
+import org.bukkit.Location;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigs;
+import us.talabrek.ultimateskyblock.uSkyBlock;
+import us.talabrek.ultimateskyblock.world.WorldManager;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Exercises the {@link IslandInfo} warp state machine (setWarpLocation / hasWarp / setWarp /
+ * getWarpLocation) against a REAL IslandInfo backed by a temp island config file.
+ *
+ * <p>These warp methods only read/write the island's own YAML config (plus
+ * {@code plugin.getWorldManager().getWorld()} to reconstruct a {@link Location}), so no
+ * RuntimeConfig is required and RuntimeConfigs#current() is never stubbed.</p>
+ *
+ * <p>Not covered here, deferred to the live-server harness: the {@code lock()} guard that
+ * deactivates an active warp (IslandInfo#lock, ~line 631). {@code lock()} calls the static
+ * {@code WorldGuardHandler.islandLock()}, whose body references WorldGuard
+ * {@code RegionManager}/{@code ProtectedRegion} types. WorldGuard is a compileOnly dependency and
+ * is absent from the unit-test classpath, so invoking {@code lock()} would fail with
+ * NoClassDefFoundError before ever reaching the warp-deactivation guard.</p>
+ */
+public class IslandInfoWarpTest {
+    @TempDir
+    Path tempDir;
+
+    private uSkyBlock plugin;
+    private RuntimeConfigs runtimeConfigs;
+
+    @BeforeEach
+    public void setUp() {
+        plugin = mock(uSkyBlock.class);
+        runtimeConfigs = mock(RuntimeConfigs.class);
+        // getWarpLocation() reconstructs a Location via plugin.getWorldManager().getWorld();
+        // a WorldManager whose getWorld() returns null (the mock default) is enough to assert the
+        // stored block coordinates and orientation.
+        WorldManager worldManager = mock(WorldManager.class);
+        doReturn(worldManager).when(plugin).getWorldManager();
+    }
+
+    @Test
+    public void freshIslandHasNoActiveWarp() throws Exception {
+        IslandInfo island = createIslandInfo();
+
+        assertThat(island.hasWarp(), is(false));
+        assertThat(island.getWarpLocation(), is(nullValue()));
+    }
+
+    @Test
+    public void setWarpLocationActivatesWarp() throws Exception {
+        IslandInfo island = createIslandInfo();
+
+        island.setWarpLocation(new Location(null, 100, 64, -200, 90.0f, 45.0f));
+
+        assertThat(island.hasWarp(), is(true));
+    }
+
+    @Test
+    public void nullWarpLocationIsIgnored() throws Exception {
+        IslandInfo island = createIslandInfo();
+
+        island.setWarpLocation(null);
+
+        assertThat(island.hasWarp(), is(false));
+        assertThat(island.getWarpLocation(), is(nullValue()));
+    }
+
+    @Test
+    public void getWarpLocationReconstructsBlockCoordsAndOrientation() throws Exception {
+        IslandInfo island = createIslandInfo();
+        island.setWarpLocation(new Location(null, 100, 64, -200, 90.0f, 45.0f));
+
+        Location warp = island.getWarpLocation();
+
+        assertThat(warp, is(notNullValue()));
+        assertThat(warp.getBlockX(), is(100));
+        assertThat(warp.getBlockY(), is(64));
+        assertThat(warp.getBlockZ(), is(-200));
+        assertThat(warp.getYaw(), is(90.0f));
+        assertThat(warp.getPitch(), is(45.0f));
+    }
+
+    @Test
+    public void setWarpTogglesActiveFlagAndGatesGetWarpLocation() throws Exception {
+        IslandInfo island = createIslandInfo();
+        island.setWarpLocation(new Location(null, 10, 70, 20, 0.0f, 0.0f));
+        assertThat(island.hasWarp(), is(true));
+
+        island.setWarp(false);
+        assertThat(island.hasWarp(), is(false));
+        assertThat(island.getWarpLocation(), is(nullValue()));
+
+        island.setWarp(true);
+        assertThat(island.hasWarp(), is(true));
+        Location reactivated = island.getWarpLocation();
+        assertThat(reactivated, is(notNullValue()));
+        assertThat(reactivated.getBlockX(), is(10));
+        assertThat(reactivated.getBlockY(), is(70));
+        assertThat(reactivated.getBlockZ(), is(20));
+    }
+
+    @Test
+    public void warpStateSurvivesConfigReload() throws Exception {
+        IslandInfo island = createIslandInfo();
+        island.setWarpLocation(new Location(null, 5, 65, -5, 12.0f, 34.0f));
+        island.saveToFile();
+
+        IslandInfo reloaded = new IslandInfo("island", plugin, runtimeConfigs, islandDir());
+
+        assertThat(reloaded.hasWarp(), is(true));
+        Location warp = reloaded.getWarpLocation();
+        assertThat(warp, is(notNullValue()));
+        assertThat(warp.getBlockX(), is(5));
+        assertThat(warp.getBlockY(), is(65));
+        assertThat(warp.getBlockZ(), is(-5));
+        assertThat(warp.getYaw(), is(12.0f));
+        assertThat(warp.getPitch(), is(34.0f));
+    }
+
+    private IslandInfo createIslandInfo() throws Exception {
+        return new IslandInfo("island", plugin, runtimeConfigs, islandDir());
+    }
+
+    /**
+     * Returns the island directory, seeding a fresh version-3 island config on first use. Once the
+     * config exists (e.g. after {@link IslandInfo#saveToFile()}) it is left untouched so a reload
+     * reads back the persisted warp state.
+     */
+    private Path islandDir() throws Exception {
+        Path dir = tempDir.resolve("island-info");
+        File islandConfigFile = new File(dir.toFile(), "island.yml");
+        if (!islandConfigFile.exists()) {
+            dir.toFile().mkdirs();
+            YamlConfiguration config = new YamlConfiguration();
+            config.set("version", 3);
+            config.save(islandConfigFile);
+        }
+        return dir;
+    }
+}


### PR DESCRIPTION
Round-2 series, part 4: fast, version-agnostic **unit** tests for `IslandInfo` party/membership and warp bookkeeping, built on a real `IslandInfo` over a temp-dir YAML (the `IslandInfoLogFormatTest` pattern).

## Coverage (3 classes, 17 tests)
- **IslandInfoPartyTest** — member read-side (`getMembers`/`getMemberUUIDs`/`getPartySize`/`isMember`/`isLeader`), `getMaxPartySize` (perk default vs per-island override), ban/unban + trust/untrust round-trips via `getBans`/`getTrustees`.
- **IslandInfoWarpTest** — the warp state machine: `setWarpLocation` activates `hasWarp`, `getWarpLocation` reconstructs stored coords/orientation, `setWarp` toggles, and a full save→reload disk round-trip.
- **WarpCommandGateTest** — the `/is warp <player>` gate (trusted visitor warps to an inactive-warp island; untrusted visitor blocked).

## Left to the live harness (non-brittle)
`addMember`/`removeMember` and the `lock()`-deactivates-warp guard call `WorldGuardHandler` statics that load WorldGuard types absent from the unit-test classpath. Their write-side is covered read-side by seeding the config.

## ⚠️ Bug found (fixed separately)
While writing the ban tests I found `IslandInfo.banPlayer(OfflinePlayer)` (single-arg) delegates to `trustPlayer(...)` instead of `banPlayer(target, null)` — the single-arg overload *trusts* instead of *bans*. It's an unused-internally but **public API** method. Fixed in a separate PR with a regression test; these tests use the correct two-arg overload.

## Validation
`./gradlew :uSkyBlock-Core:test` — BUILD SUCCESSFUL, 281 tests, 0 failures.

> Committed `--no-gpg-sign` (1Password signing agent locked mid-session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)