### PR TITLE
fix: restore message delivery on Paper 26.x

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ net-kyori-adventure-platform-bukkit = "4.4.1"
 net-milkbowl-vault-vaultapi = "1.7"
 org-apache-commons-commons-lang3 = "3.20.0"
 org-apache-httpcomponents-client5-httpclient5 = "5.6.4"
+org-apache-logging-log4j = "2.25.5"
 org-apache-maven-maven-artifact = "3.9.16"
 org-bstats-bstats-bukkit = "3.2.1"
 org-hamcrest-hamcrest = "3.0"
@@ -59,6 +60,7 @@ org-jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref 
 org-junit-jupiter-junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "org-junit-jupiter" }
 org-junit-jupiter-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "org-junit-jupiter" }
 org-junit-platform-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "org-junit-jupiter" }
+org-apache-logging-log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "org-apache-logging-log4j" }
 org-mockito-mockito-core = { module = "org.mockito:mockito-core", version.ref = "org-mockito-mockito-core" }
 org-mvplugins-multiverse-core-multiverse-core = { module = "org.mvplugins.multiverse.core:multiverse-core", version.ref = "org-mvplugins-multiverse-core-multiverse-core" }
 org-mvplugins-multiverse-inventories-multiverse-inventories = { module = "org.mvplugins.multiverse.inventories:multiverse-inventories", version.ref = "org-mvplugins-multiverse-inventories-multiverse-inventories" }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/player/NotificationManager.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/player/NotificationManager.java
@@ -1,6 +1,7 @@
 package us.talabrek.ultimateskyblock.player;
 
 import com.google.inject.Inject;
+import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.kyori.adventure.text.Component;
 import org.bukkit.command.CommandSender;
@@ -8,12 +9,46 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
+/**
+ * Delivers {@link Component}s to senders, preferring the server's own Adventure support.
+ *
+ * <p>Paper implements {@link Audience} directly on {@link CommandSender}, so no bridge is needed
+ * there. Spigot does not, and still needs adventure-platform.</p>
+ *
+ * <p>The distinction is not cosmetic. adventure-platform picks a rendering path by probing facets,
+ * each guarded by an {@code isSupported()} that swallows Throwable; when none applies it returns
+ * {@link Audience#empty()}, which discards every message with no exception and no log line. On
+ * Paper 26.x that is what happens: the server supplies Adventure, shadowing the older serializer
+ * chain adventure-platform 4.4.1 pulls in transitively, and the facets meet an Adventure they were
+ * not built against. The live-server harness shows this precisely - paper-max and paper-canary fail
+ * the {@code message-delivery} scenario while spigot-min, spigot-max and paper-min all pass, so the
+ * bridge is sound on Spigot (including 26.2) and only unusable on modern Paper.</p>
+ *
+ * <p>Routing through the native audience on Paper therefore skips the broken layer entirely, while
+ * Spigot keeps full fidelity - hover, click and hex - rather than being downgraded to legacy colour
+ * codes. The bridge is created lazily so it is never constructed on Paper at all.</p>
+ */
 public class NotificationManager {
-    private final BukkitAudiences audiences;
+    private final Plugin plugin;
+    private volatile BukkitAudiences audiences;
 
     @Inject
     public NotificationManager(Plugin plugin) {
-        audiences = BukkitAudiences.create(plugin);
+        this.plugin = plugin;
+    }
+
+    private @NotNull BukkitAudiences audiences() {
+        BukkitAudiences local = audiences;
+        if (local == null) {
+            synchronized (this) {
+                local = audiences;
+                if (local == null) {
+                    local = BukkitAudiences.create(plugin);
+                    audiences = local;
+                }
+            }
+        }
+        return local;
     }
 
     /**
@@ -23,19 +58,29 @@ public class NotificationManager {
      * @param component Component to send to the given player
      */
     public void sendActionBar(@NotNull Player player, @NotNull Component component) {
-        audiences.player(player).sendActionBar(component);
+        if (player instanceof Audience audience) {
+            audience.sendActionBar(component);
+        } else {
+            audiences().player(player).sendActionBar(component);
+        }
     }
 
     public void sendMessage(@NotNull CommandSender sender, @NotNull Component component) {
-        // Route every sender (players included) through BukkitAudiences. The previous player-only
-        // branch used BungeeComponentSerializer, whose static init calls
-        // GsonComponentSerializer.Builder.downsampleColors(); Paper 26.2 ships an Adventure release
-        // that removed that method, so the legacy Bungee path threw NoSuchMethodError on enable.
-        // BukkitAudiences renders natively on both Paper and Spigot, so this is portable.
-        audiences.sender(sender).sendMessage(component);
+        if (sender instanceof Audience audience) {
+            audience.sendMessage(component);
+        } else {
+            audiences().sender(sender).sendMessage(component);
+        }
     }
 
     public void shutdown() {
-        audiences.close();
+        BukkitAudiences local;
+        synchronized (this) {
+            local = audiences;
+            audiences = null;
+        }
+        if (local != null) {
+            local.close();
+        }
     }
 }

--- a/uSkyBlock-ittest/build.gradle.kts
+++ b/uSkyBlock-ittest/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
 dependencies {
     compileOnly(projects.uSkyBlockCore)
     compileOnly(libs.org.spigotmc.spigot.api)
+    compileOnly(libs.net.kyori.adventure.api)
+    // Server-provided; used only to observe real console output in the message-delivery scenario.
+    compileOnly(libs.org.apache.logging.log4j.core)
     // See uSkyBlock-Core: WorldGuard is server-provided; drop its bundled WorldEdit lineage and the
     // guava/gson the server ships so its strict metadata pins don't conflict on the compile classpath.
     compileOnly(libs.com.sk89q.worldguard.worldguard.bukkit) {

--- a/uSkyBlock-ittest/src/main/java/us/talabrek/ultimateskyblock/ittest/IntegrationTestPlugin.java
+++ b/uSkyBlock-ittest/src/main/java/us/talabrek/ultimateskyblock/ittest/IntegrationTestPlugin.java
@@ -1,6 +1,11 @@
 package us.talabrek.ultimateskyblock.ittest;
 
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import net.kyori.adventure.text.Component;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -24,6 +29,7 @@ import us.talabrek.ultimateskyblock.challenge.ChallengeKey;
 import us.talabrek.ultimateskyblock.challenge.ChallengeLogic;
 import us.talabrek.ultimateskyblock.handler.WorldGuardHandler;
 import us.talabrek.ultimateskyblock.island.IslandInfo;
+import us.talabrek.ultimateskyblock.message.Msg;
 import us.talabrek.ultimateskyblock.player.PlayerInfo;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 import us.talabrek.ultimateskyblock.ittest.result.AtomicVerdictWriter;
@@ -61,6 +67,7 @@ public final class IntegrationTestPlugin extends JavaPlugin implements Listener 
     private static final Duration SETUP_TIMEOUT = Duration.ofSeconds(90);
     private static final Duration PLAYER_TIMEOUT = Duration.ofSeconds(90);
     private static final Duration ISLAND_TIMEOUT = Duration.ofSeconds(120);
+    private static final long MESSAGE_SETTLE_TICKS = 20L;
 
     private final AtomicBoolean running = new AtomicBoolean();
     private final ScenarioLogCapture logCapture = new ScenarioLogCapture();
@@ -128,6 +135,7 @@ public final class IntegrationTestPlugin extends JavaPlugin implements Listener 
             this.shutdownWhenDone = shutdownWhenDone;
             this.writer = new AtomicVerdictWriter(resultDirectory.resolve(phase + ".jsonl"));
             scenarios.add(new ScenarioDefinition("harness-canary", Verdict.Category.HARNESS_ERROR, this::canary));
+            scenarios.add(new ScenarioDefinition("message-delivery", Verdict.Category.PLUGIN_FAIL, this::messageDelivery));
             if (phase.equals("fresh")) {
                 scenarios.add(new ScenarioDefinition("initial-setup", Verdict.Category.DEPENDENCY_FAIL, this::initialSetup));
                 if (Boolean.parseBoolean(System.getProperty("uskyblock.ittest.playerFlows", "true"))) {
@@ -364,6 +372,68 @@ public final class IntegrationTestPlugin extends JavaPlugin implements Listener 
                     "scheme " + entry.getKey() + " schematic is unreadable");
             }
             scenario.pass("all challenge IDs and configured schematics parsed; display item rendered");
+        }
+
+        /**
+         * Pins the message-delivery path: a {@link Component} handed to {@link Msg} must actually
+         * reach the sender.
+         *
+         * <p>Every player-facing string in uSkyBlock travels
+         * {@code Msg -> NotificationManager -> adventure-platform}. When no platform facet applies,
+         * adventure returns {@code Audience.empty()}, which discards messages silently - no
+         * exception, no console output, no clue for the player. The plugin then looks alive while
+         * being entirely mute, which is indistinguishable from a command bug.</p>
+         *
+         * <p>This scenario sends a unique marker to the console sender through the configured
+         * delivery and asserts it is emitted. It deliberately does not touch NotificationManager's
+         * internals, so it stays valid across changes to how delivery is implemented.</p>
+         */
+        private void messageDelivery(Scenario scenario) {
+            requireUsb();
+            String marker = "usb-ittest-msg-" + UUID.randomUUID();
+            AtomicBoolean seen = new AtomicBoolean();
+
+            org.apache.logging.log4j.core.Logger root;
+            try {
+                root = (org.apache.logging.log4j.core.Logger) LogManager.getRootLogger();
+            } catch (Throwable throwable) {
+                scenario.skip("cannot observe console output on this server: " + throwable);
+                return;
+            }
+
+            AbstractAppender appender = new AbstractAppender(marker, null, null, true, Property.EMPTY_ARRAY) {
+                @Override
+                public void append(LogEvent event) {
+                    if (event == null || event.getMessage() == null) return;
+                    if (event.getMessage().getFormattedMessage().contains(marker)) seen.set(true);
+                }
+            };
+            appender.start();
+            root.addAppender(appender);
+
+            try {
+                Msg.send(Bukkit.getConsoleSender(), Component.text(marker));
+                Player player = Bukkit.getPlayerExact(PLAYER_NAME);
+                if (player != null) Msg.send(player, Component.text(marker + "-player"));
+            } catch (Throwable throwable) {
+                root.removeAppender(appender);
+                appender.stop();
+                scenario.fail(Verdict.Category.PLUGIN_FAIL, throwable);
+                return;
+            }
+
+            // Console appenders may be asynchronous; settle before judging.
+            Bukkit.getScheduler().runTaskLater(IntegrationTestPlugin.this, () -> {
+                root.removeAppender(appender);
+                appender.stop();
+                if (seen.get()) {
+                    scenario.pass("console message delivered through the configured Msg delivery");
+                } else {
+                    scenario.fail(Verdict.Category.PLUGIN_FAIL,
+                        "a Component sent through Msg never reached the console: the configured delivery "
+                            + "discarded it silently (adventure-platform yields Audience.empty() when no facet applies)");
+                }
+            }, MESSAGE_SETTLE_TICKS);
         }
 
         private final class Scenario {


### PR DESCRIPTION
On Paper 26.x uSkyBlock sends no chat messages at all. Commands run, GUIs open,
islands generate — but every piece of text is discarded. There is no exception and
no console output, so the plugin looks healthy while being entirely mute.

## Cause

Every player-facing string travels `Msg -> NotificationManager -> adventure-platform`.
adventure-platform picks a rendering path by probing facets, each guarded by an
`isSupported()` that swallows `Throwable`. When none applies it returns
`Audience.empty()`, which discards messages silently.

On Paper the server supplies Adventure, which shadows the older serializer chain
adventure-platform 4.4.1 pulls in transitively, so the facets meet an Adventure they
were not built against. Spigot has no server-provided Adventure, uses the plugin's own
coherent chain, and is unaffected — including on 26.2.

Introduced in 2ef16ea (3.6.0), which replaced a loud `NoSuchMethodError` on the
BungeeCord path with this silent discard.

## Fix

Paper implements `Audience` directly on `CommandSender`, so route through it there and
skip the broken layer. Spigot keeps adventure-platform and full fidelity — hover, click
and hex — rather than being downgraded to legacy colour codes. The bridge is now created
lazily, so it is never constructed on Paper at all.

## Evidence

New `message-delivery` scenario, run on every lane in both phases. It sends a marker
through the configured `Msg` delivery to the console sender and asserts it is actually
emitted, observing real console output rather than `NotificationManager` internals — so
it stays valid across changes to how delivery is implemented.

| lane | Minecraft | test only | test + fix |
|---|---|---|---|
| paper-min | 1.21.10 | pass | pass |
| spigot-min | 1.21.10 | pass | pass |
| spigot-max | 26.2 | pass | pass |
| paper-max | 26.2 | **fail** | pass |
| paper-canary | latest | **fail** | pass |

`spigot-max` passing in both columns is the load-bearing result: same plugin, same
platform library, same Minecraft version, so the break is Paper-specific rather than an
Adventure 4.26 incompatibility. `paper-min` passing bounds it to the 26.x line.

## Scope

The scenario asserts **arrival**, not fidelity — it sends a plain-text component, so a
legacy-serialisation fallback would also pass it. Spigot fidelity is preserved by that
path being unchanged code, not by test. Worth a packet-capture scenario only if
adventure-platform eventually breaks on Spigot too and the serialisation has to change.

## Unrelated flake seen while running this

`paper-max` failed once on `scanLogs` finding spark's shutdown noise:

```
[ERROR]: [STDERR] [me.lucko.spark...Logger$1] Uncaught exception thrown in thread spark-monitoring-1-thread-1
[WARN]: java.util.concurrent.CancellationException
```

spark cancels its own monitoring tasks at shutdown and then calls `FutureTask.get()` on
them. It races with log closure, so it appears on some Paper 26.x runs and not others —
it passed on re-run, and `paper-canary` ran the identical build without it. Not addressed
here: allowlisting the bare `CancellationException` would swallow a real shutdown bug,
which is a class of failure this harness should keep catching.
