### PR TITLE
Prepare 3.6.1 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=3.7.0-SNAPSHOT
+version=3.6.1
 
 # Supported Minecraft versions for published releases.
 minecraftVersions=1.21.10,1.21.11,26.1,26.1.1,26.1.2,26.2


### PR DESCRIPTION
Patch release off current master.

Sets `version=3.6.1`. Master returns to `3.7.0-SNAPSHOT` in a follow-up commit after the tag, matching the 3.6.0 flow (`Prepare 3.6.0 release` -> tag -> `Start 3.7.0-SNAPSHOT development`).

Contents are patch-appropriate: the Paper 26.x message-delivery fix (#200), a download-URL correction, and dependency bumps. No API or config changes.