### PR TITLE
Start 3.7.0-SNAPSHOT development

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=3.6.1
+version=3.7.0-SNAPSHOT
 
 # Supported Minecraft versions for published releases.
 minecraftVersions=1.21.10,1.21.11,26.1,26.1.1,26.1.2,26.2


### PR DESCRIPTION
Returns master to `3.7.0-SNAPSHOT` after the v3.6.1 tag, matching the flow used for 3.6.0 (`Prepare 3.6.0 release` -> tag -> `Start 3.7.0-SNAPSHOT development`).

Version-only change.