### PR TITLE
fix: remove the silent failure paths around island level

### DIFF
--- a/uSkyBlock-Core/src/main/i18n/keys.admin_ops.pot
+++ b/uSkyBlock-Core/src/main/i18n/keys.admin_ops.pot
@@ -380,12 +380,20 @@ msgstr ""
 msgid "Use <cmd>/usb reload</cmd> to fully reload locale-aware config resources."
 msgstr ""
 
+#: uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/admin/AbstractIslandInfoCommand.java
+msgid "You are not standing on an island. <muted>Supply a player name instead."
+msgstr ""
+
 #: uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/admin/AdminIslandCommand.java
 msgid "You may need to go to spawn, or relog, to see the changes."
 msgstr ""
 
 #: uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/admin/PurgeCommand.java
 msgid "You must provide the age in days to purge!"
+msgstr ""
+
+#: uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/admin/AbstractPlayerInfoCommand.java
+msgid "You must supply a player name."
 msgstr ""
 
 #: uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/admin/PerkCommand.java

--- a/uSkyBlock-Core/src/main/i18n/keys.player_facing.pot
+++ b/uSkyBlock-Core/src/main/i18n/keys.player_facing.pot
@@ -413,6 +413,11 @@ msgstr ""
 msgid "Copper Golems"
 msgstr ""
 
+#: uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/InfoCommand.java
+#: uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/LevelCommand.java
+msgid "Could not calculate the island level. <muted>Please contact a server admin."
+msgstr ""
+
 #: uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/uSkyBlock.java
 msgid "Could not create your island. Please contact a server moderator."
 msgstr ""

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/admin/AbstractIslandInfoCommand.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/admin/AbstractIslandInfoCommand.java
@@ -7,6 +7,7 @@ import us.talabrek.ultimateskyblock.island.IslandInfo;
 import us.talabrek.ultimateskyblock.player.PlayerInfo;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import static us.talabrek.ultimateskyblock.message.Placeholder.unparsed;
@@ -30,27 +31,38 @@ public abstract class AbstractIslandInfoCommand extends AbstractPlayerInfoComman
     }
 
     @Override
+    protected void onMissingPlayerArgument(CommandSender sender) {
+        // Handled in execute(): without a player name we can still resolve the island the sender
+        // is standing on, and only report once that fallback has failed too.
+    }
+
+    @Override
     public boolean execute(CommandSender sender, String alias, Map<String, Object> data, String... args) {
         if (super.execute(sender, alias, data, args)) {
             PlayerInfo playerInfo = (PlayerInfo) data.get("playerInfo");
-            if (playerInfo != null) {
-                IslandInfo islandInfo = uSkyBlock.getInstance().getIslandInfo(playerInfo);
-                if (islandInfo != null && args.length > 0) {
-                    String[] subArgs = new String[args.length - 1];
-                    System.arraycopy(args, 1, subArgs, 0, subArgs.length);
-                    doExecute(sender, playerInfo, islandInfo, subArgs);
-                    return true;
-                } else {
-                    sendErrorTr(sender, "Player <player> has no island.", unparsed("player", playerInfo.getPlayerName(), PRIMARY));
-                }
+            if (playerInfo == null) {
+                return false;
             }
-        } else if (sender instanceof Player && WorldGuardHandler.getIslandNameAt(((Player) sender).getLocation()) != null) {
-            IslandInfo islandInfo = uSkyBlock.getInstance().getIslandInfo(WorldGuardHandler.getIslandNameAt(((Player) sender).getLocation()));
+            IslandInfo islandInfo = uSkyBlock.getInstance().getIslandInfo(playerInfo);
+            if (islandInfo == null) {
+                sendErrorTr(sender, "Player <player> has no island.", unparsed("player", playerInfo.getPlayerName(), PRIMARY));
+                return false;
+            }
+            // super.execute() only succeeds when a player name was supplied, so args[0] is it.
+            doExecute(sender, playerInfo, islandInfo, Arrays.copyOfRange(args, 1, args.length));
+            return true;
+        }
+        if (args.length == 0 && sender instanceof Player player) {
+            String islandName = WorldGuardHandler.getIslandNameAt(player.getLocation());
+            IslandInfo islandInfo = islandName != null ? uSkyBlock.getInstance().getIslandInfo(islandName) : null;
             if (islandInfo != null) {
                 doExecute(sender, null, islandInfo, args);
                 return true;
             }
+            sendErrorTr(sender, "You are not standing on an island. <muted>Supply a player name instead.");
+            return false;
         }
+        // A player name was supplied but did not resolve; super.execute() already said so.
         return false;
     }
 }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/admin/AbstractIslandInfoCommand.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/admin/AbstractIslandInfoCommand.java
@@ -27,40 +27,46 @@ public abstract class AbstractIslandInfoCommand extends AbstractPlayerInfoComman
 
     @Override
     protected final void doExecute(CommandSender sender, PlayerInfo playerInfo) {
-        // Not used
-    }
-
-    @Override
-    protected void onMissingPlayerArgument(CommandSender sender) {
-        // Handled in execute(): without a player name we can still resolve the island the sender
-        // is standing on, and only report once that fallback has failed too.
+        // execute() is overridden and routes to the island-aware doExecute below, so the parent's
+        // player-only variant is never reached. Fail loudly rather than silently doing nothing if
+        // that ever stops being true.
+        throw new UnsupportedOperationException(
+            getClass().getName() + " routes through doExecute(CommandSender, PlayerInfo, IslandInfo, String...)");
     }
 
     @Override
     public boolean execute(CommandSender sender, String alias, Map<String, Object> data, String... args) {
+        if (args.length == 0) {
+            // No player name given. A Player can still be resolved from where they stand; any
+            // other sender has no location to fall back to.
+            if (sender instanceof Player player) {
+                String islandName = WorldGuardHandler.getIslandNameAt(player.getLocation());
+                IslandInfo islandInfo = islandName != null ? uSkyBlock.getInstance().getIslandInfo(islandName) : null;
+                if (islandInfo != null) {
+                    doExecute(sender, null, islandInfo, args);
+                    return true;
+                }
+                sendErrorTr(sender, "You are not standing on an island. <muted>Supply a player name instead.");
+            } else {
+                onMissingPlayerArgument(sender);
+            }
+            return false;
+        }
         if (super.execute(sender, alias, data, args)) {
+            // super.execute() only succeeds after putting a non-null playerInfo in data, and only
+            // when a player name was supplied - so args[0] is that name.
             PlayerInfo playerInfo = (PlayerInfo) data.get("playerInfo");
             if (playerInfo == null) {
-                return false;
+                throw new IllegalStateException(
+                    "AbstractPlayerInfoCommand.execute returned true without storing a playerInfo");
             }
             IslandInfo islandInfo = uSkyBlock.getInstance().getIslandInfo(playerInfo);
             if (islandInfo == null) {
                 sendErrorTr(sender, "Player <player> has no island.", unparsed("player", playerInfo.getPlayerName(), PRIMARY));
                 return false;
             }
-            // super.execute() only succeeds when a player name was supplied, so args[0] is it.
             doExecute(sender, playerInfo, islandInfo, Arrays.copyOfRange(args, 1, args.length));
             return true;
-        }
-        if (args.length == 0 && sender instanceof Player player) {
-            String islandName = WorldGuardHandler.getIslandNameAt(player.getLocation());
-            IslandInfo islandInfo = islandName != null ? uSkyBlock.getInstance().getIslandInfo(islandName) : null;
-            if (islandInfo != null) {
-                doExecute(sender, null, islandInfo, args);
-                return true;
-            }
-            sendErrorTr(sender, "You are not standing on an island. <muted>Supply a player name instead.");
-            return false;
         }
         // A player name was supplied but did not resolve; super.execute() already said so.
         return false;

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/admin/AbstractPlayerInfoCommand.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/admin/AbstractPlayerInfoCommand.java
@@ -30,7 +30,21 @@ public abstract class AbstractPlayerInfoCommand extends AbstractCommand {
                 return true;
             }
             sendErrorTr(sender, "Invalid player <player> supplied.", unparsed("player", args[0], PRIMARY));
+        } else {
+            onMissingPlayerArgument(sender);
         }
         return false;
+    }
+
+    /**
+     * Called when no player argument was supplied.
+     *
+     * <p>The default tells the sender what is missing. Subclasses that can still resolve a target
+     * another way - see {@link AbstractIslandInfoCommand}, which falls back to the island the
+     * sender is standing on - override this to stay quiet here and report for themselves once
+     * their own fallback has also failed.</p>
+     */
+    protected void onMissingPlayerArgument(CommandSender sender) {
+        sendErrorTr(sender, "You must supply a player name.");
     }
 }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/admin/AbstractPlayerInfoCommand.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/admin/AbstractPlayerInfoCommand.java
@@ -37,12 +37,11 @@ public abstract class AbstractPlayerInfoCommand extends AbstractCommand {
     }
 
     /**
-     * Called when no player argument was supplied.
+     * Reports that no player argument was supplied.
      *
-     * <p>The default tells the sender what is missing. Subclasses that can still resolve a target
-     * another way - see {@link AbstractIslandInfoCommand}, which falls back to the island the
-     * sender is standing on - override this to stay quiet here and report for themselves once
-     * their own fallback has also failed.</p>
+     * <p>Exposed so subclasses that intercept {@link #execute} can reuse the same message - and
+     * the same msgid - once their own fallback has failed. {@link AbstractIslandInfoCommand} does
+     * exactly that for senders with no location to fall back to.</p>
      */
     protected void onMissingPlayerArgument(CommandSender sender) {
         sendErrorTr(sender, "You must supply a player name.");

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/InfoCommand.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/InfoCommand.java
@@ -119,9 +119,18 @@ public class InfoCommand extends RequireIslandCommand {
         };
         try {
             PatienceTester.startRunning(player, "usb.island.info.active");
-            plugin.calculateScoreAsync(player, playerInfo.locationForParty(), showInfo);
+            if (!plugin.calculateScoreAsync(player, playerInfo.locationForParty(), showInfo)) {
+                // showInfo carries every message this command produces; without it the command is
+                // silent. The cooldown must go too, or the retry answers "be patient" instead.
+                PatienceTester.stopRunning(player, "usb.island.info.active");
+                sendErrorTr(player, "Could not calculate the island level. <muted>Ask an administrator to check the console.");
+                return false;
+            }
         } catch (Exception e) {
+            PatienceTester.stopRunning(player, "usb.island.info.active");
             logger.log(Level.SEVERE, "Error while calculating Island Level", e);
+            sendErrorTr(player, "Could not calculate the island level. <muted>Ask an administrator to check the console.");
+            return false;
         }
         return true;
     }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/InfoCommand.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/InfoCommand.java
@@ -123,13 +123,13 @@ public class InfoCommand extends RequireIslandCommand {
                 // showInfo carries every message this command produces; without it the command is
                 // silent. The cooldown must go too, or the retry answers "be patient" instead.
                 PatienceTester.stopRunning(player, "usb.island.info.active");
-                sendErrorTr(player, "Could not calculate the island level. <muted>Ask an administrator to check the console.");
+                sendErrorTr(player, "Could not calculate the island level. <muted>Please contact a server admin.");
                 return false;
             }
         } catch (Exception e) {
             PatienceTester.stopRunning(player, "usb.island.info.active");
             logger.log(Level.SEVERE, "Error while calculating Island Level", e);
-            sendErrorTr(player, "Could not calculate the island level. <muted>Ask an administrator to check the console.");
+            sendErrorTr(player, "Could not calculate the island level. <muted>Please contact a server admin.");
             return false;
         }
         return true;

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/LevelCommand.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/LevelCommand.java
@@ -91,12 +91,18 @@ public class LevelCommand extends RequireIslandCommand {
             }
         };
         if (shouldRecalculate) {
-            plugin.getServer().getScheduler().runTaskLater(plugin, () -> plugin.calculateScoreAsync(player, info.locationForParty(), new Callback<us.talabrek.ultimateskyblock.api.model.IslandScore>() {
-                @Override
-                public void run() {
-                    plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, showInfo, 10L);
+            plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
+                boolean started = plugin.calculateScoreAsync(player, info.locationForParty(), new Callback<us.talabrek.ultimateskyblock.api.model.IslandScore>() {
+                    @Override
+                    public void run() {
+                        plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, showInfo, 10L);
+                    }
+                });
+                if (!started) {
+                    // showInfo only runs from the callback, so without this the command is silent.
+                    sendErrorTr(player, "Could not calculate the island level. <muted>Ask an administrator to check the console.");
                 }
-            }), 1L);
+            }, 1L);
         } else {
             showInfo.run();
         }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/LevelCommand.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/command/island/LevelCommand.java
@@ -98,9 +98,9 @@ public class LevelCommand extends RequireIslandCommand {
                         plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, showInfo, 10L);
                     }
                 });
-                if (!started) {
+                if (!started && player.isOnline()) {
                     // showInfo only runs from the callback, so without this the command is silent.
-                    sendErrorTr(player, "Could not calculate the island level. <muted>Ask an administrator to check the console.");
+                    sendErrorTr(player, "Could not calculate the island level. <muted>Please contact a server admin.");
                 }
             }, 1L);
         } else {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/event/InternalEvents.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/event/InternalEvents.java
@@ -61,11 +61,14 @@ public class InternalEvents implements Listener {
 
     @EventHandler
     public void onInfoEvent(IslandInfoEvent e) {
-        if (!plugin.calculateScoreAsync(e.getPlayer(), LocationUtil.getIslandName(e.getIslandLocation()), e.getCallback())) {
+        String islandName = LocationUtil.getIslandName(e.getIslandLocation());
+        if (!plugin.calculateScoreAsync(e.getPlayer(), islandName, e.getCallback())) {
             // IslandInfoEvent exposes no failure channel, so a consumer waiting on the callback
-            // would wait forever with nothing logged on its behalf.
-            plugin.getLogger().warning(() -> "IslandInfoEvent callback will not run for island at "
-                + LocationUtil.asString(e.getIslandLocation()) + "; its level could not be calculated.");
+            // cannot learn this; the log is the only signal. Reuse the already-computed name rather
+            // than re-deriving from the Location, whose World is a WeakReference that throws once
+            // the world is unloaded.
+            plugin.getLogger().warning(() -> "IslandInfoEvent callback will not run for island '"
+                + islandName + "'; its level could not be calculated.");
         }
     }
 }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/event/InternalEvents.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/event/InternalEvents.java
@@ -61,6 +61,11 @@ public class InternalEvents implements Listener {
 
     @EventHandler
     public void onInfoEvent(IslandInfoEvent e) {
-        plugin.calculateScoreAsync(e.getPlayer(), LocationUtil.getIslandName(e.getIslandLocation()), e.getCallback());
+        if (!plugin.calculateScoreAsync(e.getPlayer(), LocationUtil.getIslandName(e.getIslandLocation()), e.getCallback())) {
+            // IslandInfoEvent exposes no failure channel, so a consumer waiting on the callback
+            // would wait forever with nothing logged on its behalf.
+            plugin.getLogger().warning(() -> "IslandInfoEvent callback will not run for island at "
+                + LocationUtil.asString(e.getIslandLocation()) + "; its level could not be calculated.");
+        }
     }
 }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/AweLevelLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/AweLevelLogic.java
@@ -18,7 +18,7 @@ public class AweLevelLogic extends CommonLevelLogic {
     }
 
     @Override
-    public void calculateScoreAsync(Location l, Callback<IslandScore> callback) {
+    public boolean calculateScoreAsync(Location l, Callback<IslandScore> callback) {
         throw new UnsupportedOperationException("Not supported until WorldEdit releases a Bukkit 1.13 version");
             /*
         if (running.contains(l)) {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/ChunkSnapshotLevelLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/ChunkSnapshotLevelLogic.java
@@ -14,6 +14,7 @@ import us.talabrek.ultimateskyblock.api.async.Callback;
 import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfig;
 import us.talabrek.ultimateskyblock.config.runtime.RuntimeConfigs;
 import us.talabrek.ultimateskyblock.handler.WorldGuardHandler;
+import us.talabrek.ultimateskyblock.util.LocationUtil;
 import us.talabrek.ultimateskyblock.island.task.ChunkSnapShotTask;
 import us.talabrek.ultimateskyblock.uSkyBlock;
 import us.talabrek.ultimateskyblock.util.Scheduler;
@@ -51,13 +52,18 @@ public class ChunkSnapshotLevelLogic extends CommonLevelLogic {
     }
 
     @Override
-    public void calculateScoreAsync(final Location l, final Callback<IslandScore> callback) {
+    public boolean calculateScoreAsync(final Location l, final Callback<IslandScore> callback) {
         // TODO: 10/05/2015 - R4zorax: Ensure no overlapping calls to this one happen...
         logger.entering(this.getClass().getName(), "calculateScoreAsync");
         // is further threading needed here?
         final ProtectedRegion region = WorldGuardHandler.getIslandRegionAt(l);
         if (region == null) {
-            return;
+            // Callers schedule all of their work inside the callback, so returning quietly here
+            // strands it: /is info and /is level print nothing, and RecalculateTopTen stops
+            // draining its queue for good.
+            logger.warning(() -> "No island region at " + LocationUtil.asString(l)
+                + "; cannot calculate island level. The island's WorldGuard region is missing.");
+            return false;
         }
         RuntimeConfig.Async asyncConfig = runtimeConfigs.current().async();
         scheduler.sync(new ChunkSnapShotTask(scheduler, asyncConfig, l, region, new Callback<>() {
@@ -80,6 +86,7 @@ public class ChunkSnapshotLevelLogic extends CommonLevelLogic {
                 }));
             }
         }));
+        return true;
     }
 
     private void calculateScoreAndCallback(ProtectedRegion region, List<ChunkSnapshot> snapshotsOverworld, ProtectedRegion netherRegion, List<ChunkSnapshot> snapshotsNether, Callback<IslandScore> callback) {

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/ChunkSnapshotLevelLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/ChunkSnapshotLevelLogic.java
@@ -61,8 +61,10 @@ public class ChunkSnapshotLevelLogic extends CommonLevelLogic {
             // Callers schedule all of their work inside the callback, so returning quietly here
             // strands it: /is info and /is level print nothing, and RecalculateTopTen stops
             // draining its queue for good.
-            logger.warning(() -> "No island region at " + LocationUtil.asString(l)
-                + "; cannot calculate island level. The island's WorldGuard region is missing.");
+            // Deliberately does not name a cause: getIslandRegionAt also returns null when the
+            // world has no WorldGuard RegionManager at all, which is a different fix.
+            logger.warning(() -> "No island region resolved at " + LocationUtil.asString(l)
+                + "; cannot calculate island level and the callback will not run.");
             return false;
         }
         RuntimeConfig.Async asyncConfig = runtimeConfigs.current().async();

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/LevelLogic.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/level/LevelLogic.java
@@ -4,5 +4,18 @@ import org.bukkit.Location;
 import us.talabrek.ultimateskyblock.api.async.Callback;
 
 public interface LevelLogic {
-    void calculateScoreAsync(Location l, Callback<IslandScore> callback);
+    /**
+     * Starts an asynchronous score calculation for the island at the given location.
+     *
+     * <p>{@link Callback} carries no failure channel, so the return value is the only way a caller
+     * can tell that its callback will never run. Implementations must log the reason before
+     * returning {@code false}; a caller that ignores it leaves whatever it scheduled in the
+     * callback permanently pending.</p>
+     *
+     * @param l        island location to score
+     * @param callback invoked on success only
+     * @return {@code true} if the callback will be invoked, {@code false} if the calculation could
+     *         not be started (already logged)
+     */
+    boolean calculateScoreAsync(Location l, Callback<IslandScore> callback);
 }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/task/RecalculateTopTen.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/task/RecalculateTopTen.java
@@ -25,13 +25,20 @@ public class RecalculateTopTen extends BukkitRunnable {
     public void run() {
         String islandName = locations.poll();
         if (islandName != null) {
-            plugin.calculateScoreAsync(null, islandName, new Callback<>() {
+            boolean started = plugin.calculateScoreAsync(null, islandName, new Callback<>() {
                 @Override
                 public void run() {
                     // We use the deprecated on purpose (the other would fail).
                     scheduler.async(RecalculateTopTen.this);
                 }
             });
+            if (!started) {
+                // The queue is only advanced from inside the callback, so a single unscoreable
+                // island would otherwise stall the whole recalculation for good. Skip it instead.
+                plugin.getLogger().warning(() -> "Skipping island '" + islandName
+                    + "' in top-ten recalculation; its level could not be calculated.");
+                scheduler.async(RecalculateTopTen.this);
+            }
         } else {
             plugin.fireAsyncEvent(new uSkyBlockEvent(null, uSkyBlock.getAPI(), uSkyBlockEvent.Cause.RANK_UPDATED));
         }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/task/RecalculateTopTen.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/island/task/RecalculateTopTen.java
@@ -28,8 +28,11 @@ public class RecalculateTopTen extends BukkitRunnable {
             boolean started = plugin.calculateScoreAsync(null, islandName, new Callback<>() {
                 @Override
                 public void run() {
-                    // We use the deprecated on purpose (the other would fail).
-                    scheduler.async(RecalculateTopTen.this);
+                    // Cast to Runnable deliberately: this class extends BukkitRunnable, and
+                    // Scheduler.async(BukkitRunnable) delegates to runTaskAsynchronously, whose
+                    // checkNotYetScheduled() throws once the instance has been scheduled - which it
+                    // has, by RecalculateRunnable. Submitting it as a plain Runnable reschedules.
+                    scheduler.async((Runnable) RecalculateTopTen.this);
                 }
             });
             if (!started) {
@@ -37,7 +40,7 @@ public class RecalculateTopTen extends BukkitRunnable {
                 // island would otherwise stall the whole recalculation for good. Skip it instead.
                 plugin.getLogger().warning(() -> "Skipping island '" + islandName
                     + "' in top-ten recalculation; its level could not be calculated.");
-                scheduler.async(RecalculateTopTen.this);
+                scheduler.async((Runnable) RecalculateTopTen.this);
             }
         } else {
             plugin.fireAsyncEvent(new uSkyBlockEvent(null, uSkyBlock.getAPI(), uSkyBlockEvent.Cause.RANK_UPDATED));

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/uSkyBlock.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/uSkyBlock.java
@@ -900,7 +900,9 @@ public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManage
     public boolean calculateScoreAsync(final Player player, String islandName, final Callback<us.talabrek.ultimateskyblock.api.model.IslandScore> callback) {
         final IslandInfo islandInfo = getIslandInfo(islandName);
         if (islandInfo == null) {
-            getLogger().warning(() -> "No island known as '" + islandName
+            // IslandLogic.getIslandInfo(String) yields null for a null name or while in
+            // maintenance mode; an unknown-but-valid name is manufactured by its CacheLoader.
+            getLogger().warning(() -> "Could not resolve island info for name '" + islandName
                 + "'; cannot calculate island level and the callback will not run.");
             return false;
         }

--- a/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/uSkyBlock.java
+++ b/uSkyBlock-Core/src/main/java/us/talabrek/ultimateskyblock/uSkyBlock.java
@@ -893,9 +893,18 @@ public class uSkyBlock extends JavaPlugin implements uSkyBlockAPI, CommandManage
         return new IslandScore(blockScore, score.getTop());
     }
 
-    public void calculateScoreAsync(final Player player, String islandName, final Callback<us.talabrek.ultimateskyblock.api.model.IslandScore> callback) {
+    /**
+     * @return {@code true} if the callback will be invoked, {@code false} if the calculation could
+     *         not be started (already logged). See {@link LevelLogic#calculateScoreAsync}.
+     */
+    public boolean calculateScoreAsync(final Player player, String islandName, final Callback<us.talabrek.ultimateskyblock.api.model.IslandScore> callback) {
         final IslandInfo islandInfo = getIslandInfo(islandName);
-        getLevelLogic().calculateScoreAsync(islandInfo.getIslandLocation(), new Callback<>() {
+        if (islandInfo == null) {
+            getLogger().warning(() -> "No island known as '" + islandName
+                + "'; cannot calculate island level and the callback will not run.");
+            return false;
+        }
+        return getLevelLogic().calculateScoreAsync(islandInfo.getIslandLocation(), new Callback<>() {
             @Override
             public void run() {
                 IslandScore score = adjustScore(getState(), islandInfo);

--- a/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/event/InternalEventsTest.java
+++ b/uSkyBlock-Core/src/test/java/us/talabrek/ultimateskyblock/event/InternalEventsTest.java
@@ -80,7 +80,7 @@ public class InternalEventsTest {
 
         doReturn(true).when(fakePlugin).restartPlayerIsland(any(), any(), any());
         doNothing().when(fakePlugin).createIsland(any(), any());
-        doNothing().when(fakePlugin).calculateScoreAsync(any(), any(), any());
+        doReturn(true).when(fakePlugin).calculateScoreAsync(any(), any(), any());
     }
 
     @Test


### PR DESCRIPTION
`Callback` has no failure channel, so a caller could not tell that its callback would
never run. Each of these sites returned quietly and left whatever it had scheduled
inside the callback permanently pending — with nothing in the console either.

## What was silent

`ChunkSnapshotLevelLogic.calculateScoreAsync` returned without invoking the callback when
`WorldGuardHandler.getIslandRegionAt(l)` returned null, and logged nothing. Four consumers:

| consumer | consequence |
|---|---|
| `/is info` | prints nothing, and leaks the 30s patience cooldown so the retry answers "be patient" |
| `/is level` | prints nothing when a recalculation is due |
| `IslandInfoEvent` | API callback never fires; consumers wait forever |
| `RecalculateTopTen` | advances its queue **only** from inside the callback |

`uSkyBlock.calculateScoreAsync` additionally dereferenced a null `IslandInfo`.

`AbstractPlayerInfoCommand.execute` returned `false` without a word when no player
argument was supplied, and `AbstractIslandInfoCommand.execute` did the same at its final
return — which is why `/usb is info` with no argument, off-island, produced nothing.

## Approach

`LevelLogic.calculateScoreAsync` now returns whether the callback will run, and
implementations must log before refusing. Every caller handles the refusal: the commands
tell the player and clear the cooldown, `RecalculateTopTen` skips the island and keeps
draining, `InternalEvents` logs.

No branch is left doing nothing. Where a state is unreachable by construction it throws
rather than returning quietly — the sealed `doExecute(CommandSender, PlayerInfo)` hook
throws `UnsupportedOperationException`, and a null `playerInfo` after a successful
`super.execute()` throws `IllegalStateException`.

## Also repairs a pre-existing regression

`RecalculateTopTen extends BukkitRunnable`, so `scheduler.async(RecalculateTopTen.this)`
bound to `Scheduler.async(BukkitRunnable)` → `runTaskAsynchronously` →
`checkNotYetScheduled()`, which throws once the instance has been scheduled — which it has,
by `RecalculateRunnable`. **The success path has thrown since `a0404c3e` ("Move all
scheduling to Scheduler", v3.2.0)**, which rebound a plain-`Runnable` submission to the
`BukkitRunnable` overload. Both sites now cast to `Runnable`.

**Scope is narrower than it first looks.** The auto path is the only affected one:

| path | behaviour | affected |
|---|---|---|
| `/is top`, `GenTopTenCommand` → `IslandLogic.generateTopTen` | reads persisted `islandInfo.getLevel()` off disk, sorts, fires `RANK_UPDATED` | no |
| `island.autoRefreshScore` → `RecalculateRunnable` → `RecalculateTopTen` | recomputes levels via `calculateScoreAsync` | yes |

So the leaderboard itself was never broken — only the background *refreshing* of the levels
it sorts, and those still updated whenever a player ran `/is level` or `/is info` (the
wrapper calls `islandInfo.setLevel(...)`). The shipped default `autoRefreshScore` is `0m`,
so on default configuration the affected code never ran at all.

Verified that `RecalculateTopTen` is the only self-scheduling `BukkitRunnable` in Core —
the other nine subclasses never reschedule themselves, and `IncrementalRunnable` (the engine
behind chunk snapshots, generation and purge) `implements Runnable`, so its
`scheduler.sync(this, …)` binds to the safe overload.

The failure mode is not merely inferred from `checkNotYetScheduled()`: it is present once in
production history, from `/is reset` on `v3.2.0-SNAPSHOT` in Dec 2025 —
`IllegalStateException: Already scheduled as 552`. That path has been reworked across three
releases since and static analysis finds nothing on master that could reproduce it, so it is
evidence the mechanism is real rather than a second open bug.

## Scope note on IslandInfoEvent

For the other consumers the fix is real. Here the consumer's `Callback` still never runs
and still has no way to learn that — the event exposes only `getIslandLocation()` and
`getCallback()`. The change makes it **diagnosable**, not fixed. A proper failure channel
needs an APIv2 addition; follow-up worth filing.

## Behaviour change worth review

The standing-on-an-island fallback no longer runs when a player name **was** supplied but
did not resolve. That case already reported an invalid player, and silently retargeting to
wherever the sender happens to stand is surprising.

In practice this was already dead code: the default `bukkit` PlayerDB resolves any string
through `Bukkit.getOfflinePlayer(String)`, which never returns null, so `super.execute()`
could not fail with arguments present. Only `MemoryPlayerDB` could. The one real
consequence is that `/usb island get|set` require a player name — which they always did.

## Compatibility

`void` → `boolean` on `uSkyBlock.calculateScoreAsync` is binary-incompatible for anything
compiled against `ovh.uskyblock:uSkyBlock-Core` ≤ 3.6.1, which would see
`NoSuchMethodError`. Accepted deliberately: the stability guarantee covers
`us.talabrek.ultimateskyblock.api` (uSkyBlock-API), which this PR does not touch, and Core
3.4.2 → 3.5.0 already removed public classes on a minor bump. `LevelLogic` is Guice-bound
with no third-party registration hook. Worth a line in the 3.7.0 notes.

## Notes

`AweLevelLogic` takes the signature change only; its body is commented out and it throws.

Translation templates regenerated (`./gradlew translation`) — three new msgids, no other
churn; `extractTranslation` is idempotent against the committed `.pot` files, so
`build.yml`'s `git diff --exit-code` passes.

No new tests. The missing-region failure needs a live island whose WorldGuard region has
been removed, which the harness has no fixture for, and asserting *that the boolean is
checked* would pin the mechanism rather than the behaviour. The `InternalEventsTest` stub
change from `doNothing()` to `doReturn(true)` is load-bearing, not cosmetic: Mockito's
`DoesNothing` rejects a non-void method at stubbing time, so `doNothing()` would fail
`@BeforeEach` for all six tests.

Coverage gap worth a follow-up: no ittest scenario touches level logic,
`calculateScoreAsync`, `IslandInfoEvent` or the top-ten refresh. A scenario that sets
`autoRefreshScore`, occupies two islands and asserts **both** levels move would have caught
the `a0404c3e` regression in 2025, and unlike the missing-region case it is a fixture the
harness can support. A unit-level `RecalculateTopTenTest` is also possible, but note a
mocked `Scheduler` accepts the same `BukkitRunnable` twice, so a naive test passes while
production throws.
